### PR TITLE
feat(auth): add envelope encryption columns and migration

### DIFF
--- a/backend/open_webui/migrations/versions/a1b2c3d4e5f6_add_envelope_encryption.py
+++ b/backend/open_webui/migrations/versions/a1b2c3d4e5f6_add_envelope_encryption.py
@@ -1,0 +1,25 @@
+"""Add envelope encryption columns to auth table
+
+Revision ID: a1b2c3d4e5f6
+Revises: c440947495f3
+Create Date: 2026-02-15 00:00:00.000000
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "a1b2c3d4e5f6"
+down_revision = "c440947495f3"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column("auth", sa.Column("kdf_salt", sa.LargeBinary(), nullable=False))
+    op.add_column("auth", sa.Column("wrapped_dek", sa.LargeBinary(), nullable=False))
+
+
+def downgrade():
+    op.drop_column("auth", "wrapped_dek")
+    op.drop_column("auth", "kdf_salt")

--- a/backend/open_webui/models/auths.py
+++ b/backend/open_webui/models/auths.py
@@ -6,7 +6,7 @@ from sqlalchemy.orm import Session
 from open_webui.internal.db import Base, JSONField, get_db, get_db_context
 from open_webui.models.users import UserModel, UserProfileImageResponse, Users
 from pydantic import BaseModel
-from sqlalchemy import Boolean, Column, String, Text
+from sqlalchemy import Boolean, Column, LargeBinary, String, Text
 
 log = logging.getLogger(__name__)
 
@@ -22,6 +22,8 @@ class Auth(Base):
     email = Column(String)
     password = Column(Text)
     active = Column(Boolean)
+    kdf_salt = Column(LargeBinary, nullable=False)
+    wrapped_dek = Column(LargeBinary, nullable=False)
 
 
 class AuthModel(BaseModel):


### PR DESCRIPTION
## Summary

Add `kdf_salt` and `wrapped_dek` columns to the auth table for envelope encryption key storage.

## Changes

- Add Alembic migration `a1b2c3d4e5f6_add_envelope_encryption.py`
- Add `kdf_salt` (LargeBinary) and `wrapped_dek` (LargeBinary) columns to `Auth` model

## Related

Closes #9
