### PR TITLE
Remove ContextVar-based per-request DEK

### DIFF
--- a/backend/open_webui/utils/crypto_context.py
+++ b/backend/open_webui/utils/crypto_context.py
@@ -1,24 +1,6 @@
 import threading
 import time
-from contextvars import ContextVar
 from typing import Optional
-
-# Per-request DEK (Data Encryption Key)
-# Set by inject_dek_middleware, consumed by EncryptedJSON TypeDecorator
-_current_dek: ContextVar[Optional[bytes]] = ContextVar("current_dek", default=None)
-
-
-def get_dek() -> Optional[bytes]:
-    return _current_dek.get()
-
-
-def set_dek(dek: Optional[bytes]) -> None:
-    _current_dek.set(dek)
-
-
-def clear_dek() -> None:
-    _current_dek.set(None)
-
 
 # ---------------------------------------------------------------------------
 # In-memory DEK cache (user_id -> DEK)


### PR DESCRIPTION
## Summary
ContextVar による per-request DEK 受け渡し機構を削除。

## Changes
- `crypto_context.py` から `_current_dek`, `get_dek`, `set_dek`, `clear_dek` を削除
- `contextvars` の import を削除
- DEK キャッシュ (`cache_dek`, `get_cached_dek`, `evict_dek`) はそのまま残す

## Background
暗号化を SQLAlchemy イベントフック方式に変更する方針のため、TypeDecorator 経由の ContextVar DEK 受け渡しが不要になった。イベントフックでは `target.user_id` → `get_cached_dek(user_id)` で直接 DEK を取得する。

## Related
- Closes the ContextVar cleanup part of the encryption redesign

🤖 Generated with [Claude Code](https://claude.com/claude-code)