### PR TITLE
fix(chat): decrypt chat title in sidebar list query

### DIFF
--- a/backend/open_webui/models/chats.py
+++ b/backend/open_webui/models/chats.py
@@ -4,7 +4,12 @@ import time
 import uuid
 from typing import Optional
 
+import base64
+
 from sqlalchemy.orm import Session
+
+from open_webui.utils.crypto_utils import decrypt_value
+from open_webui.utils.crypto_context import get_cached_dek
 from open_webui.internal.db import Base, JSONField, get_db, get_db_context
 from open_webui.models.tags import TagModel, Tag, Tags
 from open_webui.models.folders import Folders
@@ -738,7 +743,7 @@ class ChatTable:
                 query = query.filter_by(archived=False)
 
             query = query.order_by(Chat.updated_at.desc()).with_entities(
-                Chat.id, Chat.title, Chat.updated_at, Chat.created_at
+                Chat.id, Chat.title, Chat.user_id, Chat.updated_at, Chat.created_at
             )
 
             if skip:
@@ -749,17 +754,31 @@ class ChatTable:
             all_chats = query.all()
 
             # result has to be destructured from sqlalchemy `row` and mapped to a dict since the `ChatModel`is not the returned dataclass.
-            return [
-                ChatTitleIdResponse.model_validate(
-                    {
-                        "id": chat[0],
-                        "title": chat[1],
-                        "updated_at": chat[2],
-                        "created_at": chat[3],
-                    }
+            result = []
+            for chat in all_chats:
+                title = chat.title
+                dek = get_cached_dek(chat.user_id)
+
+                if dek is None:
+                    raise RuntimeError(
+                        f"No DEK cached for user {chat.user_id}. "
+                        "User must re-login to access encrypted data."
+                    )
+
+                encrypted_bytes = base64.b64decode(title)
+                title = decrypt_value(encrypted_bytes, dek).decode("utf-8")
+
+                result.append(
+                    ChatTitleIdResponse.model_validate(
+                        {
+                            "id": chat.id,
+                            "title": title,
+                            "updated_at": chat.updated_at,
+                            "created_at": chat.created_at,
+                        }
+                    )
                 )
-                for chat in all_chats
-            ]
+            return result
 
     def get_chat_list_by_chat_ids(
         self,

--- a/backend/open_webui/models/chats.py
+++ b/backend/open_webui/models/chats.py
@@ -731,6 +731,13 @@ class ChatTable:
         db: Optional[Session] = None,
     ) -> list[ChatTitleIdResponse]:
         with get_db_context(db) as db:
+            dek = get_cached_dek(user_id)
+            if dek is None:
+                raise RuntimeError(
+                    f"No DEK cached for user {user_id}. "
+                    "User must re-login to access encrypted data."
+                )
+
             query = db.query(Chat).filter_by(user_id=user_id)
 
             if not include_folders:
@@ -743,7 +750,7 @@ class ChatTable:
                 query = query.filter_by(archived=False)
 
             query = query.order_by(Chat.updated_at.desc()).with_entities(
-                Chat.id, Chat.title, Chat.user_id, Chat.updated_at, Chat.created_at
+                Chat.id, Chat.title, Chat.updated_at, Chat.created_at
             )
 
             if skip:
@@ -756,17 +763,8 @@ class ChatTable:
             # result has to be destructured from sqlalchemy `row` and mapped to a dict since the `ChatModel`is not the returned dataclass.
             result = []
             for chat in all_chats:
-                title = chat.title
-                dek = get_cached_dek(chat.user_id)
-
-                if dek is None:
-                    raise RuntimeError(
-                        f"No DEK cached for user {chat.user_id}. "
-                        "User must re-login to access encrypted data."
-                    )
-
-                encrypted_bytes = base64.b64decode(title)
-                title = decrypt_value(encrypted_bytes, dek).decode("utf-8")
+                encrypted_title = base64.b64decode(chat.title)
+                title = decrypt_value(encrypted_title, dek).decode("utf-8")
 
                 result.append(
                     ChatTitleIdResponse.model_validate(


### PR DESCRIPTION
## Summary
サイドバーのチャットタイトルが暗号化されたまま表示される問題を修正。

## Background
- サイドバーのチャットタイトルは`get_chat_title_id_list_by_user_id` 関数内で `with_entities` を使って取得している。
- `with_entities` はパフォーマンスのために `chat` カラムを除外する目的で採用されていそう。
- ORM オブジェクトではなく `sqlalchemy.engine.row.Row` として返るため、SQLAlchemy の `load` イベントが発火しない。
- その結果、`with_entities` 経由で取得したタイトルは暗号化されたまま返される。
- この箇所以外にも手動で復号するところはありそうなので別途調査→ #19 

## Changes
- `models/chats.py`:
  -  `get_chat_title_id_list_by_user_id` で `with_entities` の取得カラムに `user_id` を追加し、キャッシュから DEK を取得してタイトルを復号するように変更。

## How to Test
1. サインアップしてチャットを送信
2. サイドバーにチャットタイトルが平文で表示されること

## Related
Closes #14