### PR TITLE
refactor(auth): track DEK cache per session (JTI)

### DIFF
--- a/backend/open_webui/models/auths.py
+++ b/backend/open_webui/models/auths.py
@@ -12,9 +12,16 @@ from open_webui.utils.crypto_utils import (
     wrap_dek,
     unwrap_dek,
 )
-from open_webui.utils.crypto_context import cache_dek
+from dataclasses import dataclass, field
+
 from pydantic import BaseModel
 from sqlalchemy import Boolean, Column, LargeBinary, String, Text
+
+
+@dataclass
+class UserWithDek:
+    user: UserModel
+    dek: bytes = field(repr=False)
 
 log = logging.getLogger(__name__)
 
@@ -102,7 +109,7 @@ class AuthsTable:
         role: str = "pending",
         oauth: Optional[dict] = None,
         db: Optional[Session] = None,
-    ) -> Optional[UserModel]:
+    ) -> Optional[UserWithDek]:
         with get_db_context(db) as db:
             log.info("insert_new_auth")
 
@@ -132,8 +139,7 @@ class AuthsTable:
             db.refresh(result)
 
             if result and user:
-                cache_dek(id, dek, ttl_seconds=3600)
-                return user
+                return UserWithDek(user=user, dek=dek)
             else:
                 return None
 
@@ -143,7 +149,7 @@ class AuthsTable:
         raw_password: str,
         verify_password: callable,
         db: Optional[Session] = None,
-    ) -> Optional[UserModel]:
+    ) -> Optional[UserWithDek]:
         log.info(f"authenticate_user: {email}")
 
         user = Users.get_user_by_email(email, db=db)
@@ -157,8 +163,7 @@ class AuthsTable:
                     if verify_password(auth.password):
                         kek = derive_kek(raw_password, auth.kdf_salt)
                         dek = unwrap_dek(auth.wrapped_dek, kek)
-                        cache_dek(user.id, dek, ttl_seconds=3600)
-                        return user
+                        return UserWithDek(user=user, dek=dek)
                     else:
                         return None
                 else:
@@ -218,7 +223,6 @@ class AuthsTable:
                 auth.wrapped_dek = new_wrapped_dek
                 db.commit()
 
-                cache_dek(id, dek, ttl_seconds=3600)
                 return True
         except Exception:
             log.exception("update_user_password_by_id error")

--- a/backend/open_webui/routers/auths.py
+++ b/backend/open_webui/routers/auths.py
@@ -231,36 +231,37 @@ async def update_password(
     if WEBUI_AUTH_TRUSTED_EMAIL_HEADER:
         raise HTTPException(400, detail=ERROR_MESSAGES.ACTION_PROHIBITED)
     if session_user:
-        auth = Auths.authenticate_user(
+        user_with_dek = Auths.authenticate_user(
             session_user.email,
             form_data.password,
             lambda pw: verify_password(form_data.password, pw),
             db=db,
         )
 
-        if auth:
+        if user_with_dek:
             try:
                 validate_password(form_data.new_password)
             except Exception as e:
                 raise HTTPException(400, detail=str(e))
             hashed = get_password_hash(form_data.new_password)
             success = Auths.update_user_password_by_id(
-                auth.user.id, hashed, form_data.new_password, form_data.password, db=db
+                user_with_dek.user.id, hashed, form_data.new_password, form_data.password, db=db
             )
             if success:
                 # Re-register the DEK under the current session
                 token = request.cookies.get("token") or (
                     request.headers.get("Authorization", "").replace("Bearer ", "")
                 )
-                decoded = decode_token(token) if token else None
-                if decoded:
-                    jti = decoded.get("jti")
-                    if jti:
+                token_payload = decode_token(token) if token else None
+                if token_payload:
+                    jti = token_payload.get("jti")
+                    exp = token_payload.get("exp")
+                    if jti and exp:
                         cache_dek(
-                            auth.user.id,
-                            auth.dek,
+                            user_with_dek.user.id,
+                            user_with_dek.dek,
                             jti,
-                            float(decoded.get("exp", time.time() + 86400 * 28)),
+                            float(exp),
                         )
             return success
         else:
@@ -478,7 +479,7 @@ async def ldap_auth(
                         else request.app.state.config.DEFAULT_USER_ROLE
                     )
 
-                    auth = Auths.insert_new_auth(
+                    user_with_dek = Auths.insert_new_auth(
                         email=email,
                         hashed_password=str(uuid.uuid4()),
                         name=cn,
@@ -486,14 +487,14 @@ async def ldap_auth(
                         db=db,
                     )
 
-                    if not auth:
+                    if not user_with_dek:
                         raise HTTPException(
                             500, detail=ERROR_MESSAGES.CREATE_USER_ERROR
                         )
 
                     apply_default_group_assignment(
                         request.app.state.config.DEFAULT_GROUP_ID,
-                        auth.user.id,
+                        user_with_dek.user.id,
                         db=db,
                     )
 
@@ -631,14 +632,15 @@ async def signin(
         admin_password = "admin"
 
         if Users.get_user_by_email(admin_email.lower(), db=db):
-            auth = Auths.authenticate_user(
+            user_with_dek = Auths.authenticate_user(
                 admin_email.lower(),
                 admin_password,
                 lambda pw: verify_password(admin_password, pw),
                 db=db,
             )
-            if auth:
-                user, dek = auth.user, auth.dek
+            if user_with_dek:
+                user = user_with_dek.user
+                dek = user_with_dek.dek
         else:
             if Users.has_users(db=db):
                 raise HTTPException(400, detail=ERROR_MESSAGES.EXISTING_USERS)
@@ -650,14 +652,15 @@ async def signin(
                 db=db,
             )
 
-            auth = Auths.authenticate_user(
+            user_with_dek = Auths.authenticate_user(
                 admin_email.lower(),
                 admin_password,
                 lambda pw: verify_password(admin_password, pw),
                 db=db,
             )
-            if auth:
-                user, dek = auth.user, auth.dek
+            if user_with_dek:
+                user = user_with_dek.user
+                dek = user_with_dek.dek
     else:
         if signin_rate_limiter.is_limited(form_data.email.lower()):
             raise HTTPException(
@@ -674,14 +677,15 @@ async def signin(
             # decode safely — ignore incomplete UTF-8 sequences
             form_data.password = password_bytes.decode("utf-8", errors="ignore")
 
-        auth = Auths.authenticate_user(
+        user_with_dek = Auths.authenticate_user(
             form_data.email.lower(),
             form_data.password,
             lambda pw: verify_password(form_data.password, pw),
             db=db,
         )
-        if auth:
-            user, dek = auth.user, auth.dek
+        if user_with_dek:
+            user = user_with_dek.user
+            dek = user_with_dek.dek
 
     if user:
 
@@ -781,7 +785,7 @@ async def signup(
         hashed = get_password_hash(form_data.password)
 
         role = "admin" if not has_users else request.app.state.config.DEFAULT_USER_ROLE
-        auth = Auths.insert_new_auth(
+        user_with_dek = Auths.insert_new_auth(
             form_data.email.lower(),
             hashed,
             form_data.name,
@@ -791,8 +795,9 @@ async def signup(
             db=db,
         )
 
-        if auth:
-            user, dek = auth.user, auth.dek
+        if user_with_dek:
+            user = user_with_dek.user
+            dek = user_with_dek.dek
             expires_delta = parse_duration(request.app.state.config.JWT_EXPIRES_IN)
             expires_at = None
             if expires_delta:
@@ -885,10 +890,10 @@ async def signout(
     if token:
         await invalidate_token(request, token)
 
-        decoded = decode_token(token)
-        if decoded:
-            jti = decoded.get("jti")
-            user_id = decoded.get("id")
+        token_payload = decode_token(token)
+        if token_payload:
+            jti = token_payload.get("jti")
+            user_id = token_payload.get("id")
             if jti and user_id:
                 remove_session(user_id, jti)
 
@@ -983,7 +988,7 @@ async def add_user(
             raise HTTPException(400, detail=str(e))
 
         hashed = get_password_hash(form_data.password)
-        auth = Auths.insert_new_auth(
+        user_with_dek = Auths.insert_new_auth(
             form_data.email.lower(),
             hashed,
             form_data.name,
@@ -993,8 +998,8 @@ async def add_user(
             db=db,
         )
 
-        if auth:
-            user = auth.user
+        if user_with_dek:
+            user = user_with_dek.user
             apply_default_group_assignment(
                 request.app.state.config.DEFAULT_GROUP_ID,
                 user.id,

--- a/backend/open_webui/routers/auths.py
+++ b/backend/open_webui/routers/auths.py
@@ -68,6 +68,7 @@ from open_webui.utils.webhook import post_webhook
 from open_webui.utils.access_control import get_permissions, has_permission
 from open_webui.utils.groups import apply_default_group_assignment
 
+from open_webui.utils.crypto_context import cache_dek, remove_session
 from open_webui.utils.redis import get_redis_client
 from open_webui.utils.rate_limit import RateLimiter
 
@@ -222,6 +223,7 @@ async def update_timezone(
 
 @router.post("/update/password", response_model=bool)
 async def update_password(
+    request: Request,
     form_data: UpdatePasswordForm,
     session_user=Depends(get_current_user),
     db: Session = Depends(get_session),
@@ -229,22 +231,38 @@ async def update_password(
     if WEBUI_AUTH_TRUSTED_EMAIL_HEADER:
         raise HTTPException(400, detail=ERROR_MESSAGES.ACTION_PROHIBITED)
     if session_user:
-        user = Auths.authenticate_user(
+        auth = Auths.authenticate_user(
             session_user.email,
             form_data.password,
             lambda pw: verify_password(form_data.password, pw),
             db=db,
         )
 
-        if user:
+        if auth:
             try:
                 validate_password(form_data.new_password)
             except Exception as e:
                 raise HTTPException(400, detail=str(e))
             hashed = get_password_hash(form_data.new_password)
-            return Auths.update_user_password_by_id(
-                user.id, hashed, form_data.new_password, form_data.password, db=db
+            success = Auths.update_user_password_by_id(
+                auth.user.id, hashed, form_data.new_password, form_data.password, db=db
             )
+            if success:
+                # Re-register the DEK under the current session
+                token = request.cookies.get("token") or (
+                    request.headers.get("Authorization", "").replace("Bearer ", "")
+                )
+                decoded = decode_token(token) if token else None
+                if decoded:
+                    jti = decoded.get("jti")
+                    if jti:
+                        cache_dek(
+                            auth.user.id,
+                            auth.dek,
+                            jti,
+                            float(decoded.get("exp", time.time() + 86400 * 28)),
+                        )
+            return success
         else:
             raise HTTPException(400, detail=ERROR_MESSAGES.INCORRECT_PASSWORD)
     else:
@@ -460,7 +478,7 @@ async def ldap_auth(
                         else request.app.state.config.DEFAULT_USER_ROLE
                     )
 
-                    user = Auths.insert_new_auth(
+                    auth = Auths.insert_new_auth(
                         email=email,
                         hashed_password=str(uuid.uuid4()),
                         name=cn,
@@ -468,14 +486,14 @@ async def ldap_auth(
                         db=db,
                     )
 
-                    if not user:
+                    if not auth:
                         raise HTTPException(
                             500, detail=ERROR_MESSAGES.CREATE_USER_ERROR
                         )
 
                     apply_default_group_assignment(
                         request.app.state.config.DEFAULT_GROUP_ID,
-                        user.id,
+                        auth.user.id,
                         db=db,
                     )
 
@@ -573,6 +591,9 @@ async def signin(
             detail=ERROR_MESSAGES.ACTION_PROHIBITED,
         )
 
+    user = None
+    dek = None
+
     if WEBUI_AUTH_TRUSTED_EMAIL_HEADER:
         if WEBUI_AUTH_TRUSTED_EMAIL_HEADER not in request.headers:
             raise HTTPException(400, detail=ERROR_MESSAGES.INVALID_TRUSTED_HEADER)
@@ -610,12 +631,14 @@ async def signin(
         admin_password = "admin"
 
         if Users.get_user_by_email(admin_email.lower(), db=db):
-            user = Auths.authenticate_user(
+            auth = Auths.authenticate_user(
                 admin_email.lower(),
                 admin_password,
                 lambda pw: verify_password(admin_password, pw),
                 db=db,
             )
+            if auth:
+                user, dek = auth.user, auth.dek
         else:
             if Users.has_users(db=db):
                 raise HTTPException(400, detail=ERROR_MESSAGES.EXISTING_USERS)
@@ -627,12 +650,14 @@ async def signin(
                 db=db,
             )
 
-            user = Auths.authenticate_user(
+            auth = Auths.authenticate_user(
                 admin_email.lower(),
                 admin_password,
                 lambda pw: verify_password(admin_password, pw),
                 db=db,
             )
+            if auth:
+                user, dek = auth.user, auth.dek
     else:
         if signin_rate_limiter.is_limited(form_data.email.lower()):
             raise HTTPException(
@@ -649,12 +674,14 @@ async def signin(
             # decode safely — ignore incomplete UTF-8 sequences
             form_data.password = password_bytes.decode("utf-8", errors="ignore")
 
-        user = Auths.authenticate_user(
+        auth = Auths.authenticate_user(
             form_data.email.lower(),
             form_data.password,
             lambda pw: verify_password(form_data.password, pw),
             db=db,
         )
+        if auth:
+            user, dek = auth.user, auth.dek
 
     if user:
 
@@ -663,10 +690,15 @@ async def signin(
         if expires_delta:
             expires_at = int(time.time()) + int(expires_delta.total_seconds())
 
+        jti = str(uuid.uuid4())
         token = create_token(
             data={"id": user.id},
             expires_delta=expires_delta,
+            jti=jti,
         )
+
+        if dek is not None and expires_at is not None:
+            cache_dek(user.id, dek, jti, float(expires_at))
 
         datetime_expires_at = (
             datetime.datetime.fromtimestamp(expires_at, datetime.timezone.utc)
@@ -749,7 +781,7 @@ async def signup(
         hashed = get_password_hash(form_data.password)
 
         role = "admin" if not has_users else request.app.state.config.DEFAULT_USER_ROLE
-        user = Auths.insert_new_auth(
+        auth = Auths.insert_new_auth(
             form_data.email.lower(),
             hashed,
             form_data.name,
@@ -759,16 +791,22 @@ async def signup(
             db=db,
         )
 
-        if user:
+        if auth:
+            user, dek = auth.user, auth.dek
             expires_delta = parse_duration(request.app.state.config.JWT_EXPIRES_IN)
             expires_at = None
             if expires_delta:
                 expires_at = int(time.time()) + int(expires_delta.total_seconds())
 
+            jti = str(uuid.uuid4())
             token = create_token(
                 data={"id": user.id},
                 expires_delta=expires_delta,
+                jti=jti,
             )
+
+            if expires_at is not None:
+                cache_dek(user.id, dek, jti, float(expires_at))
 
             datetime_expires_at = (
                 datetime.datetime.fromtimestamp(expires_at, datetime.timezone.utc)
@@ -846,6 +884,13 @@ async def signout(
 
     if token:
         await invalidate_token(request, token)
+
+        decoded = decode_token(token)
+        if decoded:
+            jti = decoded.get("jti")
+            user_id = decoded.get("id")
+            if jti and user_id:
+                remove_session(user_id, jti)
 
     response.delete_cookie("token")
     response.delete_cookie("oui-session")
@@ -938,7 +983,7 @@ async def add_user(
             raise HTTPException(400, detail=str(e))
 
         hashed = get_password_hash(form_data.password)
-        user = Auths.insert_new_auth(
+        auth = Auths.insert_new_auth(
             form_data.email.lower(),
             hashed,
             form_data.name,
@@ -948,7 +993,8 @@ async def add_user(
             db=db,
         )
 
-        if user:
+        if auth:
+            user = auth.user
             apply_default_group_assignment(
                 request.app.state.config.DEFAULT_GROUP_ID,
                 user.id,

--- a/backend/open_webui/test/apps/webui/routers/test_auths.py
+++ b/backend/open_webui/test/apps/webui/routers/test_auths.py
@@ -28,7 +28,7 @@ class TestAuths(AbstractPostgresTest):
     def test_update_profile(self):
         from open_webui.utils.auth import get_password_hash
 
-        auth = self.auths.insert_new_auth(
+        user_with_dek = self.auths.insert_new_auth(
             email="john.doe@openwebui.com",
             hashed_password=get_password_hash("old_password"),
             name="John Doe",
@@ -37,20 +37,20 @@ class TestAuths(AbstractPostgresTest):
             raw_password="old_password",
         )
 
-        with mock_webui_user(id=auth.user.id):
+        with mock_webui_user(id=user_with_dek.user.id):
             response = self.fast_api_client.post(
                 self.create_url("/update/profile"),
                 json={"name": "John Doe 2", "profile_image_url": "/user2.png"},
             )
         assert response.status_code == 200
-        db_user = self.users.get_user_by_id(auth.user.id)
+        db_user = self.users.get_user_by_id(user_with_dek.user.id)
         assert db_user.name == "John Doe 2"
         assert db_user.profile_image_url == "/user2.png"
 
     def test_update_password(self):
         from open_webui.utils.auth import get_password_hash
 
-        auth = self.auths.insert_new_auth(
+        user_with_dek = self.auths.insert_new_auth(
             email="john.doe@openwebui.com",
             hashed_password=get_password_hash("old_password"),
             name="John Doe",
@@ -59,7 +59,7 @@ class TestAuths(AbstractPostgresTest):
             raw_password="old_password",
         )
 
-        with mock_webui_user(id=auth.user.id):
+        with mock_webui_user(id=user_with_dek.user.id):
             response = self.fast_api_client.post(
                 self.create_url("/update/password"),
                 json={"password": "old_password", "new_password": "new_password"},
@@ -78,7 +78,7 @@ class TestAuths(AbstractPostgresTest):
     def test_signin(self):
         from open_webui.utils.auth import get_password_hash
 
-        auth = self.auths.insert_new_auth(
+        user_with_dek = self.auths.insert_new_auth(
             email="john.doe@openwebui.com",
             hashed_password=get_password_hash("password"),
             name="John Doe",
@@ -92,7 +92,7 @@ class TestAuths(AbstractPostgresTest):
         )
         assert response.status_code == 200
         data = response.json()
-        assert data["id"] == auth.user.id
+        assert data["id"] == user_with_dek.user.id
         assert data["name"] == "John Doe"
         assert data["email"] == "john.doe@openwebui.com"
         assert data["role"] == "user"
@@ -159,7 +159,7 @@ class TestAuths(AbstractPostgresTest):
         }
 
     def test_create_api_key_(self):
-        auth = self.auths.insert_new_auth(
+        user_with_dek = self.auths.insert_new_auth(
             email="john.doe@openwebui.com",
             hashed_password="password",
             name="John Doe",
@@ -167,7 +167,7 @@ class TestAuths(AbstractPostgresTest):
             role="admin",
             raw_password="password",
         )
-        with mock_webui_user(id=auth.user.id):
+        with mock_webui_user(id=user_with_dek.user.id):
             response = self.fast_api_client.post(self.create_url("/api_key"))
         assert response.status_code == 200
         data = response.json()
@@ -175,7 +175,7 @@ class TestAuths(AbstractPostgresTest):
         assert len(data["api_key"]) > 0
 
     def test_delete_api_key(self):
-        auth = self.auths.insert_new_auth(
+        user_with_dek = self.auths.insert_new_auth(
             email="john.doe@openwebui.com",
             hashed_password="password",
             name="John Doe",
@@ -183,16 +183,16 @@ class TestAuths(AbstractPostgresTest):
             role="admin",
             raw_password="password",
         )
-        self.users.update_user_api_key_by_id(auth.user.id, "abc")
-        with mock_webui_user(id=auth.user.id):
+        self.users.update_user_api_key_by_id(user_with_dek.user.id, "abc")
+        with mock_webui_user(id=user_with_dek.user.id):
             response = self.fast_api_client.delete(self.create_url("/api_key"))
         assert response.status_code == 200
         assert response.json() == True
-        db_user = self.users.get_user_by_id(auth.user.id)
+        db_user = self.users.get_user_by_id(user_with_dek.user.id)
         assert db_user.api_key is None
 
     def test_get_api_key(self):
-        auth = self.auths.insert_new_auth(
+        user_with_dek = self.auths.insert_new_auth(
             email="john.doe@openwebui.com",
             hashed_password="password",
             name="John Doe",
@@ -200,8 +200,8 @@ class TestAuths(AbstractPostgresTest):
             role="admin",
             raw_password="password",
         )
-        self.users.update_user_api_key_by_id(auth.user.id, "abc")
-        with mock_webui_user(id=auth.user.id):
+        self.users.update_user_api_key_by_id(user_with_dek.user.id, "abc")
+        with mock_webui_user(id=user_with_dek.user.id):
             response = self.fast_api_client.get(self.create_url("/api_key"))
         assert response.status_code == 200
         assert response.json() == {"api_key": "abc"}

--- a/backend/open_webui/test/apps/webui/routers/test_auths.py
+++ b/backend/open_webui/test/apps/webui/routers/test_auths.py
@@ -28,7 +28,7 @@ class TestAuths(AbstractPostgresTest):
     def test_update_profile(self):
         from open_webui.utils.auth import get_password_hash
 
-        user = self.auths.insert_new_auth(
+        auth = self.auths.insert_new_auth(
             email="john.doe@openwebui.com",
             hashed_password=get_password_hash("old_password"),
             name="John Doe",
@@ -37,20 +37,20 @@ class TestAuths(AbstractPostgresTest):
             raw_password="old_password",
         )
 
-        with mock_webui_user(id=user.id):
+        with mock_webui_user(id=auth.user.id):
             response = self.fast_api_client.post(
                 self.create_url("/update/profile"),
                 json={"name": "John Doe 2", "profile_image_url": "/user2.png"},
             )
         assert response.status_code == 200
-        db_user = self.users.get_user_by_id(user.id)
+        db_user = self.users.get_user_by_id(auth.user.id)
         assert db_user.name == "John Doe 2"
         assert db_user.profile_image_url == "/user2.png"
 
     def test_update_password(self):
         from open_webui.utils.auth import get_password_hash
 
-        user = self.auths.insert_new_auth(
+        auth = self.auths.insert_new_auth(
             email="john.doe@openwebui.com",
             hashed_password=get_password_hash("old_password"),
             name="John Doe",
@@ -59,7 +59,7 @@ class TestAuths(AbstractPostgresTest):
             raw_password="old_password",
         )
 
-        with mock_webui_user(id=user.id):
+        with mock_webui_user(id=auth.user.id):
             response = self.fast_api_client.post(
                 self.create_url("/update/password"),
                 json={"password": "old_password", "new_password": "new_password"},
@@ -78,7 +78,7 @@ class TestAuths(AbstractPostgresTest):
     def test_signin(self):
         from open_webui.utils.auth import get_password_hash
 
-        user = self.auths.insert_new_auth(
+        auth = self.auths.insert_new_auth(
             email="john.doe@openwebui.com",
             hashed_password=get_password_hash("password"),
             name="John Doe",
@@ -92,7 +92,7 @@ class TestAuths(AbstractPostgresTest):
         )
         assert response.status_code == 200
         data = response.json()
-        assert data["id"] == user.id
+        assert data["id"] == auth.user.id
         assert data["name"] == "John Doe"
         assert data["email"] == "john.doe@openwebui.com"
         assert data["role"] == "user"
@@ -159,7 +159,7 @@ class TestAuths(AbstractPostgresTest):
         }
 
     def test_create_api_key_(self):
-        user = self.auths.insert_new_auth(
+        auth = self.auths.insert_new_auth(
             email="john.doe@openwebui.com",
             hashed_password="password",
             name="John Doe",
@@ -167,7 +167,7 @@ class TestAuths(AbstractPostgresTest):
             role="admin",
             raw_password="password",
         )
-        with mock_webui_user(id=user.id):
+        with mock_webui_user(id=auth.user.id):
             response = self.fast_api_client.post(self.create_url("/api_key"))
         assert response.status_code == 200
         data = response.json()
@@ -175,7 +175,7 @@ class TestAuths(AbstractPostgresTest):
         assert len(data["api_key"]) > 0
 
     def test_delete_api_key(self):
-        user = self.auths.insert_new_auth(
+        auth = self.auths.insert_new_auth(
             email="john.doe@openwebui.com",
             hashed_password="password",
             name="John Doe",
@@ -183,16 +183,16 @@ class TestAuths(AbstractPostgresTest):
             role="admin",
             raw_password="password",
         )
-        self.users.update_user_api_key_by_id(user.id, "abc")
-        with mock_webui_user(id=user.id):
+        self.users.update_user_api_key_by_id(auth.user.id, "abc")
+        with mock_webui_user(id=auth.user.id):
             response = self.fast_api_client.delete(self.create_url("/api_key"))
         assert response.status_code == 200
         assert response.json() == True
-        db_user = self.users.get_user_by_id(user.id)
+        db_user = self.users.get_user_by_id(auth.user.id)
         assert db_user.api_key is None
 
     def test_get_api_key(self):
-        user = self.auths.insert_new_auth(
+        auth = self.auths.insert_new_auth(
             email="john.doe@openwebui.com",
             hashed_password="password",
             name="John Doe",
@@ -200,8 +200,8 @@ class TestAuths(AbstractPostgresTest):
             role="admin",
             raw_password="password",
         )
-        self.users.update_user_api_key_by_id(user.id, "abc")
-        with mock_webui_user(id=user.id):
+        self.users.update_user_api_key_by_id(auth.user.id, "abc")
+        with mock_webui_user(id=auth.user.id):
             response = self.fast_api_client.get(self.create_url("/api_key"))
         assert response.status_code == 200
         assert response.json() == {"api_key": "abc"}

--- a/backend/open_webui/utils/auth.py
+++ b/backend/open_webui/utils/auth.py
@@ -190,14 +190,19 @@ def verify_password(plain_password: str, hashed_password: str) -> bool:
     )
 
 
-def create_token(data: dict, expires_delta: Union[timedelta, None] = None) -> str:
+def create_token(
+    data: dict,
+    expires_delta: Union[timedelta, None] = None,
+    jti: Union[str, None] = None,
+) -> str:
     payload = data.copy()
 
     if expires_delta:
         expire = datetime.now(UTC) + expires_delta
         payload.update({"exp": expire})
 
-    jti = str(uuid.uuid4())
+    if jti is None:
+        jti = str(uuid.uuid4())
     payload.update({"jti": jti})
 
     encoded_jwt = jwt.encode(payload, SESSION_SECRET, algorithm=ALGORITHM)

--- a/backend/open_webui/utils/auth.py
+++ b/backend/open_webui/utils/auth.py
@@ -448,16 +448,16 @@ def create_admin_user(email: str, password: str, name: str = "Admin"):
     log.info(f"Creating admin account from environment variables: {email}")
     try:
         hashed = get_password_hash(password)
-        auth = Auths.insert_new_auth(
+        user_with_dek = Auths.insert_new_auth(
             email=email.lower(),
             hashed_password=hashed,
             name=name,
             role="admin",
             raw_password=password,
         )
-        if auth:
+        if user_with_dek:
             log.info(f"Admin account created successfully: {email}")
-            return auth.user
+            return user_with_dek.user
         else:
             log.error("Failed to create admin account from environment variables")
             return None

--- a/backend/open_webui/utils/auth.py
+++ b/backend/open_webui/utils/auth.py
@@ -443,16 +443,16 @@ def create_admin_user(email: str, password: str, name: str = "Admin"):
     log.info(f"Creating admin account from environment variables: {email}")
     try:
         hashed = get_password_hash(password)
-        user = Auths.insert_new_auth(
+        auth = Auths.insert_new_auth(
             email=email.lower(),
             hashed_password=hashed,
             name=name,
             role="admin",
             raw_password=password,
         )
-        if user:
+        if auth:
             log.info(f"Admin account created successfully: {email}")
-            return user
+            return auth.user
         else:
             log.error("Failed to create admin account from environment variables")
             return None

--- a/backend/open_webui/utils/crypto_context.py
+++ b/backend/open_webui/utils/crypto_context.py
@@ -1,19 +1,25 @@
 import threading
-import time
 from typing import Optional
 
 # ---------------------------------------------------------------------------
-# In-memory DEK cache (user_id -> DEK)
+# In-memory DEK cache with per-session (JTI) tracking.
 # Protected by mlockall (swap disabled). No Redis required.
+#
+# Structure: user_id -> (dek, {jti: expires_at, jti: expires_at...})
+# The DEK stays cached as long as at least one session is active.
 # ---------------------------------------------------------------------------
 
 _cache_lock = threading.Lock()
-_dek_cache: dict[str, tuple[bytes, float]] = {}  # user_id -> (dek, expires_at)
+_dek_cache: dict[str, tuple[bytes, dict[str, float]]] = {}
 
 
-def cache_dek(user_id: str, dek: bytes, ttl_seconds: float) -> None:
+def cache_dek(user_id: str, dek: bytes, jti: str, expires_at: float) -> None:
     with _cache_lock:
-        _dek_cache[user_id] = (dek, time.time() + ttl_seconds)
+        entry = _dek_cache.get(user_id)
+        if entry is not None:
+            entry[1][jti] = expires_at
+        else:
+            _dek_cache[user_id] = (dek, {jti: expires_at})
 
 
 def get_cached_dek(user_id: str) -> Optional[bytes]:
@@ -21,13 +27,15 @@ def get_cached_dek(user_id: str) -> Optional[bytes]:
         entry = _dek_cache.get(user_id)
         if entry is None:
             return None
-        dek, expires_at = entry
-        if time.time() > expires_at:
-            del _dek_cache[user_id]
+        dek, sessions = entry
+        if not sessions:
             return None
         return dek
 
 
-def evict_dek(user_id: str) -> None:
+def remove_session(user_id: str, jti: str) -> None:
     with _cache_lock:
-        _dek_cache.pop(user_id, None)
+        entry = _dek_cache.get(user_id)
+        if entry is None:
+            return
+        entry[1].pop(jti, None)

--- a/backend/open_webui/utils/oauth.py
+++ b/backend/open_webui/utils/oauth.py
@@ -1588,7 +1588,7 @@ class OAuthManager:
                         detail="To use OAuth, provide data encryption key to raw_password argument.",
                     )
 
-                    user = Auths.insert_new_auth(
+                    auth = Auths.insert_new_auth(
                         email=email,
                         hashed_password=get_password_hash(
                             str(uuid.uuid4())
@@ -1599,6 +1599,7 @@ class OAuthManager:
                         oauth=oauth_data,
                         db=db,
                     )
+                    user = auth.user
 
                     if auth_manager_config.WEBHOOK_URL:
                         await post_webhook(

--- a/backend/open_webui/utils/oauth.py
+++ b/backend/open_webui/utils/oauth.py
@@ -1588,7 +1588,7 @@ class OAuthManager:
                         detail="To use OAuth, provide data encryption key to raw_password argument.",
                     )
 
-                    auth = Auths.insert_new_auth(
+                    user_with_dek = Auths.insert_new_auth(
                         email=email,
                         hashed_password=get_password_hash(
                             str(uuid.uuid4())
@@ -1599,7 +1599,7 @@ class OAuthManager:
                         oauth=oauth_data,
                         db=db,
                     )
-                    user = auth.user
+                    user = user_with_dek.user
 
                     if auth_manager_config.WEBHOOK_URL:
                         await post_webhook(


### PR DESCRIPTION
## Summary

DEK キャッシュをユーザー単位の単一エントリからセッション（JTI）単位の管理に変更する。複数セッションが存在するとき、サインアウトしたセッション分だけ削除し、他のセッションが残っている間は DEK を保持する。

Closes #17

## Changes

- `crypto_context.py`:
  - キャッシュ構造を `user_id -> (dek, {jti: expires_at})` に変更
  - `evict_dek` を `remove_session` にリネーム
- `models/auths.py`:
  - `UserModel ` を `UserWithDek` dataclass に変更。Pydantic BaseModel から dataclass にすることで意図しないシリアライズを防ぎ、`dek` フィールドに `repr=False` を付与してログへの露出を防ぐ。
- `routers/auths.py`:
  - signin / signup で JTI を生成してトークンと DEK キャッシュに紐付け、signout で `remove_session` を呼び出し。
  - 各呼び出し箇所の変数名を `result` から `auth` に変更
- `utils/auth.py`:
  - `create_token` に `jti` パラメータを追加
  - `insert_new_auth` 呼び出し箇所を `auth` に統一
- `utils/oauth.py`:
  - `insert_new_auth` の戻り値が UserModel から UserWithDek になったことに伴い、result.user → auth.user に変更