### PR TITLE
fix(chat): search decrypted titles and message bodies

### DIFF
--- a/backend/open_webui/models/chats.py
+++ b/backend/open_webui/models/chats.py
@@ -29,13 +29,51 @@ from sqlalchemy import (
 )
 from sqlalchemy import or_, func, select, and_, text
 from sqlalchemy.sql import exists
-from sqlalchemy.sql.expression import bindparam
 
 ####################
 # Chat DB Schema
 ####################
 
 log = logging.getLogger(__name__)
+
+
+def _message_content_to_text(content) -> str:
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        return " ".join(
+            part.get("text", "")
+            for part in content
+            if isinstance(part, dict) and isinstance(part.get("text"), str)
+        )
+    return ""
+
+
+def _extract_chat_search_text(chat_json) -> str:
+    """
+    Collect searchable plaintext from a decrypted Chat.chat dict.
+
+    Chat.chat is encrypted at rest, so body content cannot be searched in SQL.
+    This concatenates every message's content (lowercased)
+    so the search can be performed in Python over already-decrypted chat objects.
+    """
+    if not isinstance(chat_json, dict):
+        return ""
+
+    parts = []
+
+    messages_map = chat_json.get("history", {}).get("messages")
+    if isinstance(messages_map, dict):
+        for message in messages_map.values():
+            if isinstance(message, dict):
+                parts.append(_message_content_to_text(message.get("content")))
+    else:
+        # Fallback: legacy top-level messages list
+        for message in chat_json.get("messages", []) or []:
+            if isinstance(message, dict):
+                parts.append(_message_content_to_text(message.get("content")))
+
+    return " ".join(parts).lower()
 
 
 class Chat(Base):
@@ -927,7 +965,10 @@ class ChatTable:
         db: Optional[Session] = None,
     ) -> list[ChatModel]:
         """
-        Filters chats based on a search query using Python, allowing pagination using skip and limit.
+        Search chats by title and message body.
+        Tag/folder/pinned/shared/archived filters are applied in SQL,
+        but title and body matching run in Python
+        because Chat.title and Chat.chat are encrypted at rest and their ciphertext is not searchable in SQL.
         """
         search_text = sanitize_text_for_db(search_text).lower().strip()
 
@@ -1013,20 +1054,9 @@ class ChatTable:
             # Check if the database dialect is either 'sqlite' or 'postgresql'
             dialect_name = db.bind.dialect.name
             if dialect_name == "sqlite":
-                # SQLite case: using JSON1 extension for JSON searching
-                sqlite_content_sql = (
-                    "EXISTS ("
-                    "    SELECT 1 "
-                    "    FROM json_each(Chat.chat, '$.messages') AS message "
-                    "    WHERE LOWER(message.value->>'content') LIKE '%' || :content_key || '%'"
-                    ")"
-                )
-                sqlite_content_clause = text(sqlite_content_sql)
-                query = query.filter(
-                    or_(
-                        Chat.title.ilike(bindparam("title_key")), sqlite_content_clause
-                    ).params(title_key=f"%{search_text}%", content_key=search_text)
-                )
+                # Note:
+                # title/body text matching is done in Python after load (Chat.title and Chat.chat are encrypted).
+                # Only tag filtering is applied in SQL here.
 
                 # Check if there are any tags to filter, it should have all the tags
                 if "none" in tag_ids:
@@ -1059,32 +1089,9 @@ class ChatTable:
                     )
 
             elif dialect_name == "postgresql":
-                # PostgreSQL doesn't allow null bytes in text. We filter those out by checking
-                # the JSON representation for \u0000 before attempting text extraction
-
-                # Safety filter: JSON field must not contain \u0000
-                query = query.filter(text("Chat.chat::text NOT LIKE '%\\\\u0000%'"))
-
-                # Safety filter: title must not contain actual null bytes
-                query = query.filter(text("Chat.title::text NOT LIKE '%\\x00%'"))
-
-                postgres_content_sql = """
-                EXISTS (
-                    SELECT 1
-                    FROM json_array_elements(Chat.chat->'messages') AS message
-                    WHERE json_typeof(message->'content') = 'string'
-                    AND LOWER(message->>'content') LIKE '%' || :content_key || '%'
-                )
-                """
-
-                postgres_content_clause = text(postgres_content_sql)
-
-                query = query.filter(
-                    or_(
-                        Chat.title.ilike(bindparam("title_key")),
-                        postgres_content_clause,
-                    )
-                ).params(title_key=f"%{search_text}%", content_key=search_text.lower())
+                # Note:
+                # title/body text matching is done in Python after load (Chat.title and Chat.chat are encrypted).
+                # Only tag filtering is applied in SQL here.
 
                 # Check if there are any tags to filter, it should have all the tags
                 if "none" in tag_ids:
@@ -1120,13 +1127,27 @@ class ChatTable:
                     f"Unsupported dialect: {db.bind.dialect.name}"
                 )
 
-            # Perform pagination at the SQL level
-            all_chats = query.offset(skip).limit(limit).all()
+            all_chats = query.all()
 
-            log.info(f"The number of chats: {len(all_chats)}")
+            matched = []
+            for chat in all_chats:
+                # Chat.title and Chat.chat are decrypted on load (see chat_hooks.py),
+                # so title/body matching is done in Python because the ciphertext is not searchable in SQL.
+                if search_text:
+                    title = (chat.title or "").lower()
+                    if (
+                        search_text not in title
+                        and search_text not in _extract_chat_search_text(chat.chat)
+                    ):
+                        continue
+                matched.append(chat)
+
+            page_chats = matched[skip : skip + limit]
+
+            log.info(f"The number of chats: {len(page_chats)}")
 
             # Validate and return chats
-            return [ChatModel.model_validate(chat) for chat in all_chats]
+            return [ChatModel.model_validate(chat) for chat in page_chats]
 
     def get_chats_by_folder_id_and_user_id(
         self,

--- a/backend/open_webui/test/util/test_chat_search.py
+++ b/backend/open_webui/test/util/test_chat_search.py
@@ -1,0 +1,202 @@
+import time
+
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker
+
+from open_webui.internal import db as internal_db
+from open_webui.internal.db import Base
+from open_webui.models.chats import Chat, Chats
+from open_webui.models.users import User
+from open_webui.utils import crypto_context
+from open_webui.utils.crypto_context import cache_dek
+from open_webui.utils.crypto_utils import generate_dek
+
+# Ensure Chat ORM load/save operations transparently encrypt/decrypt columns.
+import open_webui.utils.chat_hooks  # noqa: F401
+
+
+USER_ID = "chat-user"
+
+
+@pytest.fixture
+def db(monkeypatch):
+    monkeypatch.setattr(internal_db, "DATABASE_ENABLE_SESSION_SHARING", True)
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(
+        engine,
+        tables=[
+            User.__table__,
+            Chat.__table__,
+        ],
+    )
+    SessionLocal = sessionmaker(bind=engine)
+    session = SessionLocal()
+    cache_dek(USER_ID, generate_dek(), jti="jti-1", expires_at=time.time() + 3600)
+    _insert_user(session)
+    yield session
+    session.close()
+    engine.dispose()
+    crypto_context._dek_cache.clear()
+
+
+def _insert_user(db):
+    now = int(time.time())
+    db.add(
+        User(
+            id=USER_ID,
+            email="chat-user@example.com",
+            role="user",
+            name="Chat User",
+            profile_image_url="/user.png",
+            last_active_at=now,
+            created_at=now,
+            updated_at=now,
+        )
+    )
+    db.commit()
+
+
+def _chat_json(turns):
+    messages = {}
+    flat = []
+    prev = None
+    for i, (role, content) in enumerate(turns):
+        mid = f"m{i}"
+        node = {"id": mid, "role": role, "content": content, "parentId": prev}
+        messages[mid] = node
+        flat.append(node)
+        prev = mid
+    return {"history": {"messages": messages, "currentId": prev}, "messages": flat}
+
+
+def _insert_chat(
+    db,
+    chat_id,
+    title,
+    turns=None,
+    tags=None,
+    pinned=False,
+    archived=False,
+    ts=None,
+):
+    now = ts if ts is not None else int(time.time())
+    db.add(
+        Chat(
+            id=chat_id,
+            user_id=USER_ID,
+            title=title,
+            chat=_chat_json(turns or [("user", "hello")]),
+            meta={"tags": tags or []},
+            pinned=pinned,
+            archived=archived,
+            created_at=now,
+            updated_at=now,
+        )
+    )
+    db.commit()
+    db.expire_all()
+
+
+def _raw_title(db, chat_id):
+    return db.execute(
+        text("SELECT title FROM chat WHERE id = :id"),
+        {"id": chat_id},
+    ).scalar_one()
+
+
+def _search(db, query, **kwargs):
+    return Chats.get_chats_by_user_id_and_search_text(
+        USER_ID, query, db=db, **kwargs
+    )
+
+
+class TestTitleSearch:
+    def test_filters_by_decrypted_title(self, db):
+        _insert_chat(db, "c1", "Alpha project notes")
+        _insert_chat(db, "c2", "Beta meeting log")
+
+        # title is encrypted at rest -> the plaintext must not appear in the column
+        assert "Alpha" not in _raw_title(db, "c1")
+        result = _search(db, "alpha")
+        assert [c.id for c in result] == ["c1"]
+
+
+class TestBodySearch:
+    def test_matches_body_when_title_does_not(self, db):
+        _insert_chat(
+            db,
+            "c1",
+            "Untitled chat",
+            turns=[("user", "How do I configure pgvector?"), ("assistant", "Set it here")],
+        )
+        _insert_chat(db, "c2", "Untitled chat", turns=[("user", "unrelated")])
+
+        assert "pgvector" not in _raw_title(db, "c1")
+        result = _search(db, "pgvector")
+        assert [c.id for c in result] == ["c1"]
+
+    def test_matches_multimodal_text_content(self, db):
+        _insert_chat(
+            db,
+            "c1",
+            "Untitled chat",
+            turns=[("user", [{"type": "text", "text": "look at this diagram"}])],
+        )
+
+        result = _search(db, "diagram")
+        assert [c.id for c in result] == ["c1"]
+
+
+class TestSpecialTokensSearch:
+    def test_text_combined_with_tag_token(self, db):
+        _insert_chat(db, "c1", "Alpha report", tags=["foo"])
+        _insert_chat(db, "c2", "Alpha summary", tags=["bar"])
+        _insert_chat(db, "c3", "Beta report", tags=["foo"])
+
+        # "alpha" (text) AND tag:foo -> only c1 satisfies both
+        result = _search(db, "alpha tag:foo")
+        assert [c.id for c in result] == ["c1"]
+
+    def test_text_combined_with_pinned_token(self, db):
+        _insert_chat(db, "c1", "Alpha pinned", pinned=True)
+        _insert_chat(db, "c2", "Alpha normal", pinned=False)
+
+        result = _search(db, "alpha pinned:true")
+        assert [c.id for c in result] == ["c1"]
+
+
+class TestTokenOnlySearch:
+    def test_tag_token_only_returns_all_tag_matches(self, db):
+        _insert_chat(db, "c1", "Completely different title", tags=["foo"], ts=100)
+        _insert_chat(db, "c2", "Another title", tags=["foo"], ts=200)
+        _insert_chat(db, "c3", "Has no tag", tags=["bar"], ts=300)
+
+        result = _search(db, "tag:foo")
+
+        # order is updated_at desc; title text is irrelevant for a token-only query
+        assert [c.id for c in result] == ["c2", "c1"]
+
+
+class TestPagination:
+    def test_pages_cover_all_matches_without_overlap(self, db):
+        # 5 matching chats with increasing updated_at
+        for i in range(5):
+            _insert_chat(db, f"c{i}", f"Alpha note {i}", ts=1000 + i)
+
+        page1 = _search(db, "alpha", skip=0, limit=2)
+        page2 = _search(db, "alpha", skip=2, limit=2)
+        page3 = _search(db, "alpha", skip=4, limit=2)
+
+        ids1 = [c.id for c in page1]
+        ids2 = [c.id for c in page2]
+        ids3 = [c.id for c in page3]
+
+        # expected order: newest first
+        assert ids1 == ["c4", "c3"]
+        assert ids2 == ["c2", "c1"]
+        assert ids3 == ["c0"]
+
+        all_ids = ids1 + ids2 + ids3
+        assert len(all_ids) == 5  # no gaps
+        assert len(set(all_ids)) == 5  # no overlap

--- a/backend/open_webui/test/util/test_chat_search.py
+++ b/backend/open_webui/test/util/test_chat_search.py
@@ -6,7 +6,7 @@ from sqlalchemy.orm import sessionmaker
 
 from open_webui.internal import db as internal_db
 from open_webui.internal.db import Base
-from open_webui.models.chats import Chat, Chats
+from open_webui.models.chats import Chat, Chats, _extract_chat_search_text
 from open_webui.models.users import User
 from open_webui.utils import crypto_context
 from open_webui.utils.crypto_context import cache_dek
@@ -136,16 +136,77 @@ class TestBodySearch:
         result = _search(db, "pgvector")
         assert [c.id for c in result] == ["c1"]
 
-    def test_matches_multimodal_text_content(self, db):
+    def test_matches_text_part_of_multimodal_content(self, db):
         _insert_chat(
             db,
             "c1",
             "Untitled chat",
-            turns=[("user", [{"type": "text", "text": "look at this diagram"}])],
+            turns=[
+                (
+                    "user",
+                    [
+                        {"type": "text", "text": "look at this diagram"},
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": "https://example.com/photo.png"},
+                        },
+                    ],
+                )
+            ],
         )
 
         result = _search(db, "diagram")
         assert [c.id for c in result] == ["c1"]
+
+    def test_does_not_match_json_structure_of_multimodal_content(self, db):
+        _insert_chat(
+            db,
+            "c1",
+            "Untitled chat",
+            turns=[
+                (
+                    "user",
+                    [
+                        {"type": "text", "text": "please review the diagram"},
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": "https://example.com/secret-photo.png"},
+                        },
+                    ],
+                )
+            ],
+        )
+
+        for needle in ["type", "image_url", "secret-photo", "example.com", "url"]:
+            assert _search(db, needle) == [], f"unexpected hit for {needle!r}"
+
+        assert [c.id for c in _search(db, "diagram")] == ["c1"]
+
+    def test_extracts_only_visible_text_not_json_structure(self):
+        chat_json = _chat_json(
+            [
+                (
+                    "user",
+                    [
+                        {"type": "text", "text": "please review the diagram"},
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": "https://example.com/secret-photo.png"},
+                        },
+                    ],
+                )
+            ]
+        )
+
+        extracted = _extract_chat_search_text(chat_json)
+
+        assert "please review the diagram" in extracted
+        for token in ["type", "image_url", "secret-photo", "example.com", "url"]:
+            assert token not in extracted, f"{token!r} leaked into searchable text"
+
+    def test_returns_empty_for_non_dict(self):
+        assert _extract_chat_search_text(None) == ""
+        assert _extract_chat_search_text("not a dict") == ""
 
 
 class TestSpecialTokensSearch:


### PR DESCRIPTION
## Summary
暗号化導入で機能しなくなっていたチャットのタイトル検索と本文検索を修正する。
`Chat.title` / `Chat.chat`（本文）はいずれも暗号化されており SQL では検索できないため、ORM の `load` フックで復号した後に Python 側でマッチングする。

closes: #23

## Changes
- `Chat.title` / `Chat.chat`（本文）を ORM の `load` フックで復号したうえで、Python 側で部分一致判定するよう変更
- タイトルまたは本文に検索語が含まれればヒット（暗号化前の SQL `or_(title, content)` と同等のセマンティクス）
- 本文抽出ヘルパー `_extract_chat_search_text` / `_message_content_to_text` を追加
  - `history.messages`（無ければ旧形式の top-level `messages`）を走査して全メッセージの `content` を連結・小文字化
  - `content` が文字列・マルチモーダル配列 (`[{type, text}]`) の両方に対応し、`text` の値のみを抽出（キー名・型・画像 URL などの JSON 構造は対象外）
- 暗号文に対して機能しない旧来の本文検索 SQL を **削除**
  - SQLite: `json_each(Chat.chat, '$.messages')` + `Chat.title.ilike(...)` の `or_`
  - PostgreSQL: `json_array_elements(Chat.chat->'messages')` + `Chat.title.ilike(...)` の `or_`
  - AES-GCM（ランダム nonce）で暗号文が非決定的なため、SQL での本文/タイトル検索は原理的に不可。Python 側マッチングは dialect 非依存
- 不要になった PostgreSQL の NUL バイト安全フィルタ（`Chat.chat::text` / `Chat.title::text` の `NOT LIKE`）を削除（本文/タイトルを SQL で参照しなくなったため）
- ページングを SQL の `OFFSET/LIMIT` から Python のスライス（`matched[skip:skip+limit]`）へ変更（テキスト一致が Python 側に移ったため）
- メタデータ (archived / pinned / shared / folder / tag) は引き続き SQL 側で絞り込み
- 未使用になった `bindparam` import を削除

## Tests
`backend/open_webui/test/util/test_chat_search.py` を追加（10 tests, all passing）。下記 How to Test の各項目に加え、以下もカバー:
- マルチモーダルメッセージ（text + image）の **text パートはヒットする**
- JSON 構造（キー名 `type`/`image_url`/`url`、型値、画像 URL）は **ヒットしない**（検索全体＋抽出関数の単体の両面）
- 抽出関数が dict 以外の入力で空文字を返す型ガード

## How to Test
- 平文タイトルに検索語を含む/含まないチャットで結果が切り分けられること
- **メッセージ本文にのみ検索語を含むチャットがヒットすること**
- `tag:foo`, `pinned:true` などの特殊トークンと併用しても動くこと
- 検索語が特殊トークンのみ (例: `tag:foo`) のときにもタグ一致チャットが返ること
- ページング(無限スクロール)で重複・抜け落ちなく動くこと
