### PR TITLE
fix(auth): return 401 instead of 500 when DEK cache is missing

### DIFF
--- a/backend/open_webui/routers/auths.py
+++ b/backend/open_webui/routers/auths.py
@@ -68,7 +68,7 @@ from open_webui.utils.webhook import post_webhook
 from open_webui.utils.access_control import get_permissions, has_permission
 from open_webui.utils.groups import apply_default_group_assignment
 
-from open_webui.utils.crypto_context import cache_dek, remove_session
+from open_webui.utils.crypto_context import cache_dek, remove_session, get_cached_dek
 from open_webui.utils.redis import get_redis_client
 from open_webui.utils.rate_limit import RateLimiter
 
@@ -111,6 +111,11 @@ async def get_session_user(
     user=Depends(get_current_user),
     db: Session = Depends(get_session),
 ):
+    if get_cached_dek(user.id) is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Session expired. Please log in again.",
+        )
 
     auth_header = request.headers.get("Authorization")
     auth_token = get_http_authorization_cred(auth_header)

--- a/backend/open_webui/utils/auth.py
+++ b/backend/open_webui/utils/auth.py
@@ -23,6 +23,7 @@ from opentelemetry import trace
 
 
 from open_webui.utils.access_control import has_permission
+from open_webui.utils.crypto_context import get_cached_dek
 from open_webui.models.users import Users
 from open_webui.models.auths import Auths
 
@@ -419,6 +420,11 @@ def get_verified_user(user=Depends(get_current_user)):
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail=ERROR_MESSAGES.ACCESS_PROHIBITED,
         )
+    if get_cached_dek(user.id) is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Session expired. Please log in again.",
+        )
     return user
 
 
@@ -427,6 +433,11 @@ def get_admin_user(user=Depends(get_current_user)):
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail=ERROR_MESSAGES.ACCESS_PROHIBITED,
+        )
+    if get_cached_dek(user.id) is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Session expired. Please log in again.",
         )
     return user
 


### PR DESCRIPTION
## Summary
プロセス再起動でメモリ内 DEK キャッシュが消えた時、暗号化 Chat にアクセスすると `RuntimeError` が ORM の `load` フックから送出され **500 エラー** になっていた。これを認証層で **401** に変換し、フロント側の既存 auto-redirect (`+layout.svelte:780-792`) で再ログイン誘導されるようにする。

Closes #25

## Changes
以下でユーザーのDEKがあるかチェック
- `utils/auth.py:get_verified_user`
- `utils/auth.py:get_admin_user`
- `routers/auths.py:get_session_user`

## How to Test
1. ログイン後、`docker restart open-webui` などでプロセス再起動
2. ブラウザで画面リロード
3. **期待**:  401 を返し、 `/auth` に redirect → ログイン画面表示
4. 再ログインで通常通りチャット閲覧できることを確認

### コンテナ内 curl での確認(実施済み)

| Endpoint | DEK 不在時のレスポンス |
|---|---|
| `GET /api/v1/auths/` | 401 + `Session expired. Please log in again.` |
| `GET /api/v1/chats/pinned` | 401 + 同上 |
| サーバーログ | `RuntimeError: No DEK cached for user ...` のトレース消滅 |