### PR TITLE
Encrypt uploaded file contents and metadata

### DIFF
--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -61,7 +61,10 @@ from open_webui.utils import logger
 from open_webui.utils.audit import AuditLevel, AuditLoggingMiddleware
 from open_webui.utils.logger import start_logger
 from open_webui.utils.memory_lock import enable_memory_lock
-import open_webui.utils.chat_hooks  # noqa: F401 — registers SQLAlchemy event listeners
+
+# Register SQLAlchemy encryption event listeners.
+import open_webui.utils.chat_hooks  # noqa: F401
+import open_webui.utils.file_hooks  # noqa: F401
 from open_webui.socket.main import (
     MODELS,
     app as socket_app,

--- a/backend/open_webui/models/files.py
+++ b/backend/open_webui/models/files.py
@@ -1,5 +1,6 @@
 import logging
 import time
+import fnmatch
 from typing import Optional
 
 from sqlalchemy.orm import Session
@@ -216,9 +217,7 @@ class FilesTable:
                     created_at=file.created_at,
                     updated_at=file.updated_at,
                 )
-                for file in db.query(
-                    File.id, File.hash, File.meta, File.created_at, File.updated_at
-                )
+                for file in db.query(File)
                 .filter(File.id.in_(ids))
                 .order_by(File.updated_at.desc())
                 .all()
@@ -283,16 +282,17 @@ class FilesTable:
             if user_id:
                 query = query.filter_by(user_id=user_id)
 
-            pattern = self._glob_to_like_pattern(filename)
-            if pattern != "%":
-                query = query.filter(File.filename.ilike(pattern, escape="\\"))
+            files = query.order_by(File.updated_at.desc()).all()
+            if filename != "*":
+                pattern = filename.lower()
+                files = [
+                    file
+                    for file in files
+                    if fnmatch.fnmatch((file.filename or "").lower(), pattern)
+                ]
 
             return [
-                FileModel.model_validate(file)
-                for file in query.order_by(File.updated_at.desc())
-                .offset(skip)
-                .limit(limit)
-                .all()
+                FileModel.model_validate(file) for file in files[skip : skip + limit]
             ]
 
     def update_file_by_id(

--- a/backend/open_webui/models/knowledge.py
+++ b/backend/open_webui/models/knowledge.py
@@ -293,24 +293,22 @@ class KnowledgeTable:
                 # This makes the database handle filtering, even with 10k+ KBs
                 query = has_permission(db, Knowledge, query, filter)
 
-                # Apply filename search
-                if filter:
-                    q = filter.get("query")
-                    if q:
-                        query = query.filter(File.filename.ilike(f"%{q}%"))
-
                 # Order by file changes
                 query = query.order_by(File.updated_at.desc())
 
-                # Count before pagination
-                total = query.count()
-
-                if skip:
-                    query = query.offset(skip)
-                if limit:
-                    query = query.limit(limit)
-
                 rows = query.all()
+                if filter:
+                    q = filter.get("query")
+                    if q:
+                        q = q.lower()
+                        rows = [
+                            row
+                            for row in rows
+                            if q in ((row[0].filename or "").lower())
+                        ]
+
+                total = len(rows)
+                rows = rows[skip : skip + limit] if limit else rows[skip:]
 
                 items = []
                 for file, user, knowledge in rows:
@@ -429,8 +427,6 @@ class KnowledgeTable:
 
                 if filter:
                     query_key = filter.get("query")
-                    if query_key:
-                        query = query.filter(or_(File.filename.ilike(f"%{query_key}%")))
 
                     view_option = filter.get("view_option")
                     if view_option == "created":
@@ -441,12 +437,7 @@ class KnowledgeTable:
                     order_by = filter.get("order_by")
                     direction = filter.get("direction")
 
-                    if order_by == "name":
-                        if direction == "asc":
-                            query = query.order_by(File.filename.asc())
-                        else:
-                            query = query.order_by(File.filename.desc())
-                    elif order_by == "created_at":
+                    if order_by == "created_at":
                         if direction == "asc":
                             query = query.order_by(File.created_at.asc())
                         else:
@@ -462,15 +453,27 @@ class KnowledgeTable:
                 else:
                     query = query.order_by(File.updated_at.desc())
 
-                # Count BEFORE pagination
-                total = query.count()
-
-                if skip:
-                    query = query.offset(skip)
-                if limit:
-                    query = query.limit(limit)
-
                 items = query.all()
+                if filter:
+                    query_key = filter.get("query")
+                    if query_key:
+                        query_key = query_key.lower()
+                        items = [
+                            item
+                            for item in items
+                            if query_key in ((item[0].filename or "").lower())
+                        ]
+
+                    if filter.get("order_by") == "name":
+                        reverse = filter.get("direction") != "asc"
+                        items = sorted(
+                            items,
+                            key=lambda item: (item[0].filename or "").lower(),
+                            reverse=reverse,
+                        )
+
+                total = len(items)
+                items = items[skip : skip + limit] if limit else items[skip:]
 
                 files = []
                 for file, user in items:

--- a/backend/open_webui/routers/files.py
+++ b/backend/open_webui/routers/files.py
@@ -20,10 +20,11 @@ from fastapi import (
     Query,
 )
 
-from fastapi.responses import FileResponse, StreamingResponse
+from fastapi.responses import StreamingResponse
 from sqlalchemy.orm import Session
 from open_webui.internal.db import get_session, SessionLocal
 
+from open_webui.config import UPLOAD_DIR
 from open_webui.constants import ERROR_MESSAGES
 from open_webui.retrieval.vector.factory import VECTOR_DB_CLIENT
 
@@ -48,6 +49,14 @@ from open_webui.storage.provider import Storage
 
 from open_webui.utils.auth import get_admin_user, get_verified_user
 from open_webui.utils.access_control import has_access
+from open_webui.utils.crypto_context import get_cached_dek
+from open_webui.utils.crypto_utils import stream_encrypt_file
+from open_webui.utils.encrypted_files import (
+    decrypt_file_to_temp,
+    get_encrypted_file_path,
+    iter_decrypted_file,
+    remove_temp_file,
+)
 from open_webui.utils.misc import strict_match_mime_type
 from pydantic import BaseModel
 
@@ -134,10 +143,14 @@ def process_uploaded_file(
                 if strict_match_mime_type(
                     stt_supported_content_types, file.content_type
                 ):
-                    file_path_processed = Storage.get_file(file_path)
-                    result = transcribe(
-                        request, file_path_processed, file_metadata, user
-                    )
+                    file_path_processed = None
+                    try:
+                        file_path_processed = decrypt_file_to_temp(file_item)
+                        result = transcribe(
+                            request, file_path_processed, file_metadata, user
+                        )
+                    finally:
+                        remove_temp_file(file_path_processed)
 
                     process_file(
                         request,
@@ -212,6 +225,25 @@ def upload_file(
     )
 
 
+def cleanup_uploaded_file(path: str | None) -> None:
+    if not path:
+        return
+    try:
+        Path(path).unlink(missing_ok=True)
+    except Exception:
+        pass
+
+
+class DecryptedFileResponse(StreamingResponse):
+    def __init__(self, file, *, headers=None, media_type=None):
+        encrypted_path = get_encrypted_file_path(file)
+        super().__init__(
+            iter_decrypted_file(file, encrypted_path),
+            headers=headers,
+            media_type=media_type,
+        )
+
+
 def upload_file_handler(
     request: Request,
     file: UploadFile = File(...),
@@ -233,6 +265,7 @@ def upload_file_handler(
                 detail=ERROR_MESSAGES.DEFAULT("Invalid metadata format"),
             )
     file_metadata = metadata if metadata else {}
+    file_path = None
 
     try:
         unsanitized_filename = file.filename
@@ -255,19 +288,23 @@ def upload_file_handler(
                     ),
                 )
 
-        # replace filename with uuid
         id = str(uuid.uuid4())
         name = filename
-        filename = f"{id}_{filename}"
-        contents, file_path = Storage.upload_file(
+        dek = get_cached_dek(user.id)
+        if dek is None:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail=ERROR_MESSAGES.DEFAULT("User must re-login to upload files"),
+            )
+
+        storage_filename = f"{id}.owenc"
+        file_path = f"{UPLOAD_DIR}/{storage_filename}"
+        file_size = stream_encrypt_file(
             file.file,
-            filename,
-            {
-                "OpenWebUI-User-Email": user.email,
-                "OpenWebUI-User-Id": user.id,
-                "OpenWebUI-User-Name": user.name,
-                "OpenWebUI-File-Id": id,
-            },
+            file_path,
+            dek,
+            user_id=user.id,
+            file_id=id,
         )
 
         file_item = Files.insert_new_file(
@@ -283,7 +320,7 @@ def upload_file_handler(
                     "meta": {
                         "name": name,
                         "content_type": file.content_type,
-                        "size": len(contents),
+                        "size": file_size,
                         "data": file_metadata,
                     },
                 }
@@ -332,8 +369,12 @@ def upload_file_handler(
                     detail=ERROR_MESSAGES.DEFAULT("Error uploading file"),
                 )
 
+    except HTTPException:
+        cleanup_uploaded_file(file_path)
+        raise
     except Exception as e:
         log.exception(e)
+        cleanup_uploaded_file(file_path)
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=ERROR_MESSAGES.DEFAULT("Error uploading file"),
@@ -640,44 +681,39 @@ async def get_file_content_by_id(
         or has_access_to_file(id, "read", user, db=db)
     ):
         try:
-            file_path = Storage.get_file(file.path)
-            file_path = Path(file_path)
+            filename = file.meta.get("name", file.filename)
+            encoded_filename = quote(filename)
 
-            # Check if the file already exists in the cache
-            if file_path.is_file():
-                # Handle Unicode filenames
-                filename = file.meta.get("name", file.filename)
-                encoded_filename = quote(filename)  # RFC5987 encoding
+            content_type = file.meta.get("content_type")
+            headers = {}
 
-                content_type = file.meta.get("content_type")
-                filename = file.meta.get("name", file.filename)
-                encoded_filename = quote(filename)
-                headers = {}
-
-                if attachment:
+            if attachment:
+                headers["Content-Disposition"] = (
+                    f"attachment; filename*=UTF-8''{encoded_filename}"
+                )
+            else:
+                if content_type == "application/pdf" or filename.lower().endswith(
+                    ".pdf"
+                ):
+                    headers["Content-Disposition"] = (
+                        f"inline; filename*=UTF-8''{encoded_filename}"
+                    )
+                    content_type = "application/pdf"
+                elif content_type != "text/plain":
                     headers["Content-Disposition"] = (
                         f"attachment; filename*=UTF-8''{encoded_filename}"
                     )
-                else:
-                    if content_type == "application/pdf" or filename.lower().endswith(
-                        ".pdf"
-                    ):
-                        headers["Content-Disposition"] = (
-                            f"inline; filename*=UTF-8''{encoded_filename}"
-                        )
-                        content_type = "application/pdf"
-                    elif content_type != "text/plain":
-                        headers["Content-Disposition"] = (
-                            f"attachment; filename*=UTF-8''{encoded_filename}"
-                        )
 
-                return FileResponse(file_path, headers=headers, media_type=content_type)
-
-            else:
-                raise HTTPException(
-                    status_code=status.HTTP_404_NOT_FOUND,
-                    detail=ERROR_MESSAGES.NOT_FOUND,
-                )
+            return DecryptedFileResponse(
+                file,
+                headers=headers,
+                media_type=content_type,
+            )
+        except FileNotFoundError:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=ERROR_MESSAGES.NOT_FOUND,
+            )
         except Exception as e:
             log.exception(e)
             log.error("Error getting file content")
@@ -717,18 +753,16 @@ async def get_html_file_content_by_id(
         or has_access_to_file(id, "read", user, db=db)
     ):
         try:
-            file_path = Storage.get_file(file.path)
-            file_path = Path(file_path)
-
-            # Check if the file already exists in the cache
-            if file_path.is_file():
-                log.info(f"file_path: {file_path}")
-                return FileResponse(file_path)
-            else:
-                raise HTTPException(
-                    status_code=status.HTTP_404_NOT_FOUND,
-                    detail=ERROR_MESSAGES.NOT_FOUND,
-                )
+            log.info(f"file_path: {file.path}")
+            return DecryptedFileResponse(
+                file,
+                media_type=file.meta.get("content_type") or "text/html",
+            )
+        except FileNotFoundError:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=ERROR_MESSAGES.NOT_FOUND,
+            )
         except Exception as e:
             log.exception(e)
             log.error("Error getting file content")
@@ -770,13 +804,12 @@ async def get_file_content_by_id(
         }
 
         if file_path:
-            file_path = Storage.get_file(file_path)
-            file_path = Path(file_path)
-
-            # Check if the file already exists in the cache
-            if file_path.is_file():
-                return FileResponse(file_path, headers=headers)
-            else:
+            try:
+                return DecryptedFileResponse(
+                    file,
+                    headers=headers,
+                )
+            except FileNotFoundError:
                 raise HTTPException(
                     status_code=status.HTTP_404_NOT_FOUND,
                     detail=ERROR_MESSAGES.NOT_FOUND,

--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -39,6 +39,7 @@ from langchain_core.documents import Document
 from open_webui.models.files import FileModel, FileUpdateForm, Files
 from open_webui.models.knowledge import Knowledges
 from open_webui.storage.provider import Storage
+from open_webui.utils.encrypted_files import decrypt_file_to_temp, remove_temp_file
 from open_webui.internal.db import get_session
 from sqlalchemy.orm import Session
 
@@ -1663,42 +1664,45 @@ def process_file(
                 # Usage: /files/
                 file_path = file.path
                 if file_path:
-                    file_path = Storage.get_file(file_path)
-                    loader = Loader(
-                        engine=request.app.state.config.CONTENT_EXTRACTION_ENGINE,
-                        user=user,
-                        DATALAB_MARKER_API_KEY=request.app.state.config.DATALAB_MARKER_API_KEY,
-                        DATALAB_MARKER_API_BASE_URL=request.app.state.config.DATALAB_MARKER_API_BASE_URL,
-                        DATALAB_MARKER_ADDITIONAL_CONFIG=request.app.state.config.DATALAB_MARKER_ADDITIONAL_CONFIG,
-                        DATALAB_MARKER_SKIP_CACHE=request.app.state.config.DATALAB_MARKER_SKIP_CACHE,
-                        DATALAB_MARKER_FORCE_OCR=request.app.state.config.DATALAB_MARKER_FORCE_OCR,
-                        DATALAB_MARKER_PAGINATE=request.app.state.config.DATALAB_MARKER_PAGINATE,
-                        DATALAB_MARKER_STRIP_EXISTING_OCR=request.app.state.config.DATALAB_MARKER_STRIP_EXISTING_OCR,
-                        DATALAB_MARKER_DISABLE_IMAGE_EXTRACTION=request.app.state.config.DATALAB_MARKER_DISABLE_IMAGE_EXTRACTION,
-                        DATALAB_MARKER_FORMAT_LINES=request.app.state.config.DATALAB_MARKER_FORMAT_LINES,
-                        DATALAB_MARKER_USE_LLM=request.app.state.config.DATALAB_MARKER_USE_LLM,
-                        DATALAB_MARKER_OUTPUT_FORMAT=request.app.state.config.DATALAB_MARKER_OUTPUT_FORMAT,
-                        EXTERNAL_DOCUMENT_LOADER_URL=request.app.state.config.EXTERNAL_DOCUMENT_LOADER_URL,
-                        EXTERNAL_DOCUMENT_LOADER_API_KEY=request.app.state.config.EXTERNAL_DOCUMENT_LOADER_API_KEY,
-                        TIKA_SERVER_URL=request.app.state.config.TIKA_SERVER_URL,
-                        DOCLING_SERVER_URL=request.app.state.config.DOCLING_SERVER_URL,
-                        DOCLING_API_KEY=request.app.state.config.DOCLING_API_KEY,
-                        DOCLING_PARAMS=request.app.state.config.DOCLING_PARAMS,
-                        PDF_EXTRACT_IMAGES=request.app.state.config.PDF_EXTRACT_IMAGES,
-                        DOCUMENT_INTELLIGENCE_ENDPOINT=request.app.state.config.DOCUMENT_INTELLIGENCE_ENDPOINT,
-                        DOCUMENT_INTELLIGENCE_KEY=request.app.state.config.DOCUMENT_INTELLIGENCE_KEY,
-                        DOCUMENT_INTELLIGENCE_MODEL=request.app.state.config.DOCUMENT_INTELLIGENCE_MODEL,
-                        MISTRAL_OCR_API_BASE_URL=request.app.state.config.MISTRAL_OCR_API_BASE_URL,
-                        MISTRAL_OCR_API_KEY=request.app.state.config.MISTRAL_OCR_API_KEY,
-                        MINERU_API_MODE=request.app.state.config.MINERU_API_MODE,
-                        MINERU_API_URL=request.app.state.config.MINERU_API_URL,
-                        MINERU_API_KEY=request.app.state.config.MINERU_API_KEY,
-                        MINERU_API_TIMEOUT=request.app.state.config.MINERU_API_TIMEOUT,
-                        MINERU_PARAMS=request.app.state.config.MINERU_PARAMS,
-                    )
-                    docs = loader.load(
-                        file.filename, file.meta.get("content_type"), file_path
-                    )
+                    file_path = decrypt_file_to_temp(file)
+                    try:
+                        loader = Loader(
+                            engine=request.app.state.config.CONTENT_EXTRACTION_ENGINE,
+                            user=user,
+                            DATALAB_MARKER_API_KEY=request.app.state.config.DATALAB_MARKER_API_KEY,
+                            DATALAB_MARKER_API_BASE_URL=request.app.state.config.DATALAB_MARKER_API_BASE_URL,
+                            DATALAB_MARKER_ADDITIONAL_CONFIG=request.app.state.config.DATALAB_MARKER_ADDITIONAL_CONFIG,
+                            DATALAB_MARKER_SKIP_CACHE=request.app.state.config.DATALAB_MARKER_SKIP_CACHE,
+                            DATALAB_MARKER_FORCE_OCR=request.app.state.config.DATALAB_MARKER_FORCE_OCR,
+                            DATALAB_MARKER_PAGINATE=request.app.state.config.DATALAB_MARKER_PAGINATE,
+                            DATALAB_MARKER_STRIP_EXISTING_OCR=request.app.state.config.DATALAB_MARKER_STRIP_EXISTING_OCR,
+                            DATALAB_MARKER_DISABLE_IMAGE_EXTRACTION=request.app.state.config.DATALAB_MARKER_DISABLE_IMAGE_EXTRACTION,
+                            DATALAB_MARKER_FORMAT_LINES=request.app.state.config.DATALAB_MARKER_FORMAT_LINES,
+                            DATALAB_MARKER_USE_LLM=request.app.state.config.DATALAB_MARKER_USE_LLM,
+                            DATALAB_MARKER_OUTPUT_FORMAT=request.app.state.config.DATALAB_MARKER_OUTPUT_FORMAT,
+                            EXTERNAL_DOCUMENT_LOADER_URL=request.app.state.config.EXTERNAL_DOCUMENT_LOADER_URL,
+                            EXTERNAL_DOCUMENT_LOADER_API_KEY=request.app.state.config.EXTERNAL_DOCUMENT_LOADER_API_KEY,
+                            TIKA_SERVER_URL=request.app.state.config.TIKA_SERVER_URL,
+                            DOCLING_SERVER_URL=request.app.state.config.DOCLING_SERVER_URL,
+                            DOCLING_API_KEY=request.app.state.config.DOCLING_API_KEY,
+                            DOCLING_PARAMS=request.app.state.config.DOCLING_PARAMS,
+                            PDF_EXTRACT_IMAGES=request.app.state.config.PDF_EXTRACT_IMAGES,
+                            DOCUMENT_INTELLIGENCE_ENDPOINT=request.app.state.config.DOCUMENT_INTELLIGENCE_ENDPOINT,
+                            DOCUMENT_INTELLIGENCE_KEY=request.app.state.config.DOCUMENT_INTELLIGENCE_KEY,
+                            DOCUMENT_INTELLIGENCE_MODEL=request.app.state.config.DOCUMENT_INTELLIGENCE_MODEL,
+                            MISTRAL_OCR_API_BASE_URL=request.app.state.config.MISTRAL_OCR_API_BASE_URL,
+                            MISTRAL_OCR_API_KEY=request.app.state.config.MISTRAL_OCR_API_KEY,
+                            MINERU_API_MODE=request.app.state.config.MINERU_API_MODE,
+                            MINERU_API_URL=request.app.state.config.MINERU_API_URL,
+                            MINERU_API_KEY=request.app.state.config.MINERU_API_KEY,
+                            MINERU_API_TIMEOUT=request.app.state.config.MINERU_API_TIMEOUT,
+                            MINERU_PARAMS=request.app.state.config.MINERU_PARAMS,
+                        )
+                        docs = loader.load(
+                            file.filename, file.meta.get("content_type"), file_path
+                        )
+                    finally:
+                        remove_temp_file(file_path)
 
                     docs = [
                         Document(

--- a/backend/open_webui/utils/crypto_context.py
+++ b/backend/open_webui/utils/crypto_context.py
@@ -63,6 +63,13 @@ def get_cached_dek(user_id: str) -> Optional[bytes]:
         return dek
 
 
+def require_cached_dek(user_id: str) -> bytes:
+    dek = get_cached_dek(user_id)
+    if dek is None:
+        raise RuntimeError(f"No DEK cached for user {user_id}. User must re-login.")
+    return dek
+
+
 def remove_session(user_id: str, jti: str) -> None:
     with _cache_lock:
         entry = _dek_cache.get(user_id)

--- a/backend/open_webui/utils/crypto_utils.py
+++ b/backend/open_webui/utils/crypto_utils.py
@@ -1,13 +1,12 @@
 import os
 import base64
 import json
-import logging
-from typing import Optional
+import struct
+from pathlib import Path
+from typing import Any, BinaryIO, Iterator
 
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 from argon2.low_level import hash_secret_raw, Type
-
-log = logging.getLogger(__name__)
 
 NONCE_SIZE = 12     # 96 bits for AES-GCM
 DEK_SIZE = 32       # 256 bits
@@ -18,6 +17,9 @@ ARGON2_TIME_COST = 1
 ARGON2_MEMORY_COST = 2097152  # 2 GiB
 ARGON2_PARALLELISM = 4
 ARGON2_HASH_LEN = 32  # 256 bits
+ENCRYPTED_VALUE_PREFIX = "owenc:v1:"
+FILE_MAGIC = b"OWUIFILEENC1\n"
+FILE_CHUNK_SIZE = 64 * 1024
 
 
 def generate_dek() -> bytes:
@@ -66,3 +68,221 @@ def decrypt_value(encrypted_bytes: bytes, dek: bytes) -> bytes:
     ciphertext = encrypted_bytes[NONCE_SIZE:]
     aesgcm = AESGCM(dek)
     return aesgcm.decrypt(nonce, ciphertext, None)
+
+
+def is_encrypted_value(value: Any) -> bool:
+    return isinstance(value, str) and value.startswith(ENCRYPTED_VALUE_PREFIX)
+
+
+def encrypt_text(value: str | None, dek: bytes) -> str | None:
+    if value is None or is_encrypted_value(value):
+        return value
+    encrypted = encrypt_value(value.encode("utf-8"), dek)
+    return ENCRYPTED_VALUE_PREFIX + base64.b64encode(encrypted).decode("ascii")
+
+
+def decrypt_text(value: str | None, dek: bytes) -> str | None:
+    if value is None or not is_encrypted_value(value):
+        return value
+    payload = base64.b64decode(value[len(ENCRYPTED_VALUE_PREFIX) :])
+    return decrypt_value(payload, dek).decode("utf-8")
+
+
+def encrypt_json_value(value: Any, dek: bytes) -> str:
+    if is_encrypted_value(value):
+        return value
+    plaintext = json.dumps(value, ensure_ascii=False, separators=(",", ":")).encode(
+        "utf-8"
+    )
+    encrypted = encrypt_value(plaintext, dek)
+    return ENCRYPTED_VALUE_PREFIX + base64.b64encode(encrypted).decode("ascii")
+
+
+def decrypt_json_value(value: Any, dek: bytes) -> Any:
+    if not is_encrypted_value(value):
+        return value
+    payload = base64.b64decode(value[len(ENCRYPTED_VALUE_PREFIX) :])
+    plaintext = decrypt_value(payload, dek)
+    return json.loads(plaintext.decode("utf-8"))
+
+
+def _file_aad(user_id: str, file_id: str, chunk_index: int, final: bool) -> bytes:
+    return f"owui-file-v1:{user_id}:{file_id}:{chunk_index}:{int(final)}".encode(
+        "utf-8"
+    )
+
+
+def stream_encrypt_file(
+    source: BinaryIO,
+    destination_path: str | Path,
+    dek: bytes,
+    *,
+    user_id: str,
+    file_id: str,
+    chunk_size: int = FILE_CHUNK_SIZE,
+) -> int:
+    destination_path = Path(destination_path)
+    destination_path.parent.mkdir(parents=True, exist_ok=True)
+    total_size = 0
+    chunk_index = 0
+
+    try:
+        with destination_path.open("wb") as output:
+            output.write(FILE_MAGIC)
+            current = source.read(chunk_size)
+            if current == b"":
+                raise ValueError("Empty file")
+
+            while current:
+                next_chunk = source.read(chunk_size)
+                final = next_chunk == b""
+                nonce = os.urandom(NONCE_SIZE)
+                ciphertext = AESGCM(dek).encrypt(
+                    nonce,
+                    current,
+                    _file_aad(user_id, file_id, chunk_index, final),
+                )
+                output.write(struct.pack(">I", len(ciphertext)))
+                output.write(bytes([1 if final else 0]))
+                output.write(nonce)
+                output.write(ciphertext)
+
+                total_size += len(current)
+                if final:
+                    break
+                current = next_chunk
+                chunk_index += 1
+    except Exception:
+        try:
+            destination_path.unlink(missing_ok=True)
+        except Exception:
+            pass
+        raise
+
+    return total_size
+
+
+def stream_decrypt_file_to_path(
+    source_path: str | Path,
+    destination_path: str | Path,
+    dek: bytes,
+    *,
+    user_id: str,
+    file_id: str,
+) -> int:
+    source_path = Path(source_path)
+    destination_path = Path(destination_path)
+    destination_path.parent.mkdir(parents=True, exist_ok=True)
+    total_size = 0
+    chunk_index = 0
+    saw_final = False
+
+    try:
+        with source_path.open("rb") as source, destination_path.open("wb") as output:
+            if source.read(len(FILE_MAGIC)) != FILE_MAGIC:
+                raise ValueError("Invalid encrypted file")
+
+            while True:
+                length_bytes = source.read(4)
+                if length_bytes == b"":
+                    break
+                if len(length_bytes) != 4:
+                    raise ValueError("Invalid encrypted file chunk header")
+
+                ciphertext_len = struct.unpack(">I", length_bytes)[0]
+                final_flag = source.read(1)
+                nonce = source.read(NONCE_SIZE)
+                ciphertext = source.read(ciphertext_len)
+
+                if (
+                    len(final_flag) != 1
+                    or len(nonce) != NONCE_SIZE
+                    or len(ciphertext) != ciphertext_len
+                ):
+                    raise ValueError("Invalid encrypted file chunk")
+
+                final = final_flag == b"\x01"
+                plaintext = AESGCM(dek).decrypt(
+                    nonce,
+                    ciphertext,
+                    _file_aad(user_id, file_id, chunk_index, final),
+                )
+                output.write(plaintext)
+                total_size += len(plaintext)
+
+                if final:
+                    if source.read(1) != b"":
+                        raise ValueError(
+                            "Unexpected data after final encrypted file chunk"
+                        )
+                    saw_final = True
+                    break
+
+                chunk_index += 1
+
+            if not saw_final:
+                raise ValueError("Encrypted file is missing final chunk")
+    except Exception:
+        try:
+            destination_path.unlink(missing_ok=True)
+        except Exception:
+            pass
+        raise
+
+    return total_size
+
+
+def iter_decrypt_file(
+    source_path: str | Path,
+    dek: bytes,
+    *,
+    user_id: str,
+    file_id: str,
+) -> Iterator[bytes]:
+    source_path = Path(source_path)
+    chunk_index = 0
+    saw_final = False
+
+    with source_path.open("rb") as source:
+        if source.read(len(FILE_MAGIC)) != FILE_MAGIC:
+            raise ValueError("Invalid encrypted file")
+
+        while True:
+            length_bytes = source.read(4)
+            if length_bytes == b"":
+                break
+            if len(length_bytes) != 4:
+                raise ValueError("Invalid encrypted file chunk header")
+
+            ciphertext_len = struct.unpack(">I", length_bytes)[0]
+            final_flag = source.read(1)
+            nonce = source.read(NONCE_SIZE)
+            ciphertext = source.read(ciphertext_len)
+
+            if (
+                len(final_flag) != 1
+                or len(nonce) != NONCE_SIZE
+                or len(ciphertext) != ciphertext_len
+            ):
+                raise ValueError("Invalid encrypted file chunk")
+
+            final = final_flag == b"\x01"
+            plaintext = AESGCM(dek).decrypt(
+                nonce,
+                ciphertext,
+                _file_aad(user_id, file_id, chunk_index, final),
+            )
+            yield plaintext
+
+            if final:
+                if source.read(1) != b"":
+                    raise ValueError(
+                        "Unexpected data after final encrypted file chunk"
+                    )
+                saw_final = True
+                break
+
+            chunk_index += 1
+
+        if not saw_final:
+            raise ValueError("Encrypted file is missing final chunk")

--- a/backend/open_webui/utils/encrypted_files.py
+++ b/backend/open_webui/utils/encrypted_files.py
@@ -1,0 +1,71 @@
+import os
+import tempfile
+from pathlib import Path
+
+from open_webui.storage.provider import Storage
+from open_webui.utils.crypto_context import require_cached_dek
+from open_webui.utils.crypto_utils import (
+    iter_decrypt_file,
+    stream_decrypt_file_to_path,
+)
+
+
+def _get_file_attr(file, name: str):
+    if isinstance(file, dict):
+        return file.get(name)
+    return getattr(file, name)
+
+
+def _get_file_dek(file) -> bytes:
+    user_id = _get_file_attr(file, "user_id")
+    return require_cached_dek(user_id)
+
+
+def get_encrypted_file_path(file) -> Path:
+    encrypted_path = Path(Storage.get_file(_get_file_attr(file, "path")))
+    if not encrypted_path.is_file():
+        raise FileNotFoundError(encrypted_path)
+    return encrypted_path
+
+
+def decrypt_file_to_temp(file) -> str:
+    encrypted_path = get_encrypted_file_path(file)
+    user_id = _get_file_attr(file, "user_id")
+    file_id = _get_file_attr(file, "id")
+    dek = _get_file_dek(file)
+
+    fd, temp_path = tempfile.mkstemp(prefix=f"{file_id}_", suffix=".dec")
+    os.close(fd)
+
+    stream_decrypt_file_to_path(
+        encrypted_path,
+        temp_path,
+        dek,
+        user_id=user_id,
+        file_id=file_id,
+    )
+    return temp_path
+
+
+def iter_decrypted_file(file, encrypted_path: str | Path | None = None):
+    encrypted_path = (
+        Path(encrypted_path) if encrypted_path else get_encrypted_file_path(file)
+    )
+    user_id = _get_file_attr(file, "user_id")
+    file_id = _get_file_attr(file, "id")
+    dek = _get_file_dek(file)
+    return iter_decrypt_file(
+        encrypted_path,
+        dek,
+        user_id=user_id,
+        file_id=file_id,
+    )
+
+
+def remove_temp_file(path: str | None) -> None:
+    if not path:
+        return
+    try:
+        os.remove(path)
+    except FileNotFoundError:
+        pass

--- a/backend/open_webui/utils/file_hooks.py
+++ b/backend/open_webui/utils/file_hooks.py
@@ -1,0 +1,81 @@
+"""
+Encrypts filename, data, and meta on INSERT/UPDATE and decrypts on load/refresh,
+using the file owner's DEK from the in-memory cache.
+"""
+
+from sqlalchemy import event
+
+from open_webui.models.files import File
+from open_webui.utils.crypto_context import require_cached_dek
+from open_webui.utils.crypto_utils import (
+    decrypt_json_value,
+    decrypt_text,
+    encrypt_json_value,
+    encrypt_text,
+)
+
+
+def _encrypt_fields(target: File) -> None:
+    dek = require_cached_dek(target.user_id)
+
+    target._filename_plaintext = target.filename
+    target._data_plaintext = target.data
+    target._meta_plaintext = target.meta
+
+    target.filename = encrypt_text(target.filename, dek)
+    target.data = encrypt_json_value(target.data or {}, dek)
+    target.meta = encrypt_json_value(target.meta or {}, dek)
+
+
+def _decrypt_fields(target: File) -> None:
+    dek = require_cached_dek(target.user_id)
+
+    target.filename = decrypt_text(target.filename, dek)
+    target.data = decrypt_json_value(target.data, dek)
+    target.meta = decrypt_json_value(target.meta, dek)
+
+
+def _restore_plaintext(target: File) -> None:
+    if hasattr(target, "_filename_plaintext"):
+        target.filename = target._filename_plaintext
+        del target._filename_plaintext
+    if hasattr(target, "_data_plaintext"):
+        target.data = target._data_plaintext
+        del target._data_plaintext
+    if hasattr(target, "_meta_plaintext"):
+        target.meta = target._meta_plaintext
+        del target._meta_plaintext
+
+
+# -- Event listeners --------------------------------------------------------
+
+
+@event.listens_for(File, "before_insert")
+def on_before_insert(mapper, connection, target):
+    _encrypt_fields(target)
+
+
+@event.listens_for(File, "after_insert")
+def on_after_insert(mapper, connection, target):
+    _restore_plaintext(target)
+
+
+@event.listens_for(File, "before_update")
+def on_before_update(mapper, connection, target):
+    _encrypt_fields(target)
+
+
+@event.listens_for(File, "after_update")
+def on_after_update(mapper, connection, target):
+    _restore_plaintext(target)
+
+
+@event.listens_for(File, "load")
+def on_load(target, context):
+    _decrypt_fields(target)
+
+
+@event.listens_for(File, "refresh")
+def on_refresh(target, context, attrs):
+    if attrs is None or any(attr in attrs for attr in ("filename", "data", "meta")):
+        _decrypt_fields(target)

--- a/backend/open_webui/utils/files.py
+++ b/backend/open_webui/utils/files.py
@@ -11,13 +11,11 @@ from fastapi import (
     UploadFile,
 )
 from typing import Optional
-from pathlib import Path
-
-from open_webui.storage.provider import Storage
 
 from open_webui.models.chats import Chats
 from open_webui.models.files import Files
 from open_webui.routers.files import upload_file_handler
+from open_webui.utils.encrypted_files import iter_decrypted_file
 
 import mimetypes
 import base64
@@ -46,16 +44,10 @@ def get_image_base64_from_url(url: str) -> Optional[str]:
             if not file:
                 return None
 
-            file_path = Storage.get_file(file.path)
-            file_path = Path(file_path)
-
-            if file_path.is_file():
-                with open(file_path, "rb") as image_file:
-                    encoded_string = base64.b64encode(image_file.read()).decode("utf-8")
-                    content_type, _ = mimetypes.guess_type(file_path.name)
-                    return f"data:{content_type};base64,{encoded_string}"
-            else:
-                return None
+            image_data = b"".join(iter_decrypted_file(file))
+            encoded_string = base64.b64encode(image_data).decode("utf-8")
+            content_type = file.meta.get("content_type", "image/png")
+            return f"data:{content_type};base64,{encoded_string}"
 
     except Exception as e:
         return None
@@ -160,18 +152,9 @@ def get_image_base64_from_file_id(id: str) -> Optional[str]:
         return None
 
     try:
-        file_path = Storage.get_file(file.path)
-        file_path = Path(file_path)
-
-        # Check if the file already exists in the cache
-        if file_path.is_file():
-            import base64
-
-            with open(file_path, "rb") as image_file:
-                encoded_string = base64.b64encode(image_file.read()).decode("utf-8")
-                content_type, _ = mimetypes.guess_type(file_path.name)
-                return f"data:{content_type};base64,{encoded_string}"
-        else:
-            return None
+        image_data = b"".join(iter_decrypted_file(file))
+        encoded_string = base64.b64encode(image_data).decode("utf-8")
+        content_type = file.meta.get("content_type", "image/png")
+        return f"data:{content_type};base64,{encoded_string}"
     except Exception as e:
         return None


### PR DESCRIPTION
## Summary

アップロードされたファイル本体と、file テーブル上のユーザー由来メタデータを暗号化する対応です。既存の chat 暗号化と同じく、ユーザーの DEK を使ってアプリケーション層で透過的に暗号化/復号します。

## Changes

- ファイル本体を chunked AES-GCM で暗号化し、{file_id}.owenc という元ファイル名を含まない opaque な名前で保存するように変更
- file.filename, file.meta, file.data を SQLAlchemy event hook で保存時に暗号化、読み込み時に復号するように追加
- ファイル取得 API では暗号化ファイルを直接返さず、DecryptedFileResponse で復号しながら stream 返却するように変更
- RAG/STT/画像 base64 化など、保存ファイルを読む処理を暗号化ファイル対応に変更
- ilename 暗号化により DB の File.filename.ilike(...) が使えなくなるため、file/knowledge の検索処理を復号後の Python 側 filtering に変更
- DEK 必須取得用のrequire_cached_dek() を追加

## How to test

- ファイルをアップロードし、DB 上のfilename, meta, dataが平文ではなく暗号化文字列として保存されていることを確認する
- DATA_DIR/uploads 配下に {file_id}.owenc 形式で保存され、元ファイル名や元拡張子が path に含まれないことを確認する
- アップロードしたファイルを UI から開き、PDF/画像/テキストなどが復号されて正常に表示またはダウンロードできることを確認する
- RAG 処理ありでファイルをアップロードし、本文抽出と検索が正常に完了することを確認する
- ファイル名検索、knowledge 内のファイル検索が復号後のファイル名で期待どおり動くことを確認する

実施済み確認:

- touched backend files の AST parse
- touched backend files の python -m compileall`n- git diff --cached --check`n- stream_encrypt_file、stream_decrypt_file_to_path、iter_decrypt_file の暗号化/復号 roundtrip

注意点:

- RAG/STT loader は現状 path 入力を要求するため、処理中だけ一時復号ファイルを作成し、処理後に削除します。