### PR TITLE
feat(crypto): add column-level encrypt/decrypt helpers and require_cached_dek

### DIFF
--- a/backend/open_webui/test/util/test_crypto_context.py
+++ b/backend/open_webui/test/util/test_crypto_context.py
@@ -1,0 +1,54 @@
+import time
+
+import pytest
+
+from open_webui.utils import crypto_context
+from open_webui.utils.crypto_context import (
+    cache_dek,
+    get_cached_dek,
+    purge_expired_sessions,
+    remove_session,
+    require_cached_dek,
+)
+from open_webui.utils.crypto_utils import generate_dek
+
+
+@pytest.fixture(autouse=True)
+def _isolate_cache():
+    crypto_context._dek_cache.clear()
+    yield
+    crypto_context._dek_cache.clear()
+
+
+class TestRequireCachedDek:
+    def test_returns_cached_dek(self):
+        dek = generate_dek()
+        cache_dek("user-1", dek, jti="jti-1", expires_at=time.time() + 60)
+
+        assert require_cached_dek("user-1") == dek
+
+    def test_raises_when_user_not_cached(self):
+        with pytest.raises(RuntimeError, match="No DEK cached for user user-missing"):
+            require_cached_dek("user-missing")
+
+    def test_raises_when_all_sessions_expired(self):
+        dek = generate_dek()
+        cache_dek("user-1", dek, jti="jti-1", expires_at=time.time() - 1)
+        purge_expired_sessions(time.time())
+
+        with pytest.raises(RuntimeError, match="No DEK cached for user user-1"):
+            require_cached_dek("user-1")
+
+    def test_raises_after_last_session_removed(self):
+        dek = generate_dek()
+        cache_dek("user-1", dek, jti="jti-1", expires_at=time.time() + 60)
+        remove_session("user-1", "jti-1")
+
+        with pytest.raises(RuntimeError):
+            require_cached_dek("user-1")
+
+    def test_get_cached_dek_returns_none_in_same_conditions(self):
+        # Sanity: require_cached_dek and get_cached_dek must agree on "missing"
+        assert get_cached_dek("user-missing") is None
+        with pytest.raises(RuntimeError):
+            require_cached_dek("user-missing")

--- a/backend/open_webui/test/util/test_crypto_utils.py
+++ b/backend/open_webui/test/util/test_crypto_utils.py
@@ -1,0 +1,129 @@
+import base64
+
+import pytest
+from cryptography.exceptions import InvalidTag
+
+from open_webui.utils.crypto_utils import (
+    decrypt_json_value,
+    decrypt_text,
+    encrypt_json_value,
+    encrypt_text,
+    generate_dek,
+)
+
+
+@pytest.fixture
+def dek() -> bytes:
+    return generate_dek()
+
+
+class TestEncryptText:
+    def test_roundtrip_ascii(self, dek):
+        assert decrypt_text(encrypt_text("hello", dek), dek) == "hello"
+
+    def test_roundtrip_empty_string(self, dek):
+        assert decrypt_text(encrypt_text("", dek), dek) == ""
+
+    def test_roundtrip_unicode(self, dek):
+        value = "こんにちは🌸 — emoji and 漢字"
+        assert decrypt_text(encrypt_text(value, dek), dek) == value
+
+    def test_roundtrip_long_string(self, dek):
+        value = "a" * 100_000
+        assert decrypt_text(encrypt_text(value, dek), dek) == value
+
+    def test_roundtrip_marker_like_string(self, dek):
+        value = "owenc:v1:my-file.png"
+        assert decrypt_text(encrypt_text(value, dek), dek) == value
+
+    def test_none_passes_through_on_encrypt(self, dek):
+        assert encrypt_text(None, dek) is None
+
+    def test_none_passes_through_on_decrypt(self, dek):
+        assert decrypt_text(None, dek) is None
+
+    def test_output_is_ascii_base64(self, dek):
+        encrypted = encrypt_text("hello", dek)
+        # Must be ASCII-safe (no Python bytes, no non-ASCII)
+        assert isinstance(encrypted, str)
+        encrypted.encode("ascii")
+        # Must be valid base64
+        base64.b64decode(encrypted)
+
+    def test_two_encryptions_produce_different_ciphertext(self, dek):
+        # Fresh nonce per call → ciphertexts differ
+        a = encrypt_text("hello", dek)
+        b = encrypt_text("hello", dek)
+        assert a != b
+
+    def test_wrong_dek_raises(self, dek):
+        encrypted = encrypt_text("hello", dek)
+        with pytest.raises(InvalidTag):
+            decrypt_text(encrypted, generate_dek())
+
+    def test_tampered_ciphertext_raises(self, dek):
+        encrypted = encrypt_text("hello", dek)
+        raw = bytearray(base64.b64decode(encrypted))
+        raw[-1] ^= 0x01  # flip a tag bit
+        tampered = base64.b64encode(bytes(raw)).decode("ascii")
+        with pytest.raises(InvalidTag):
+            decrypt_text(tampered, dek)
+
+    def test_invalid_base64_raises(self, dek):
+        with pytest.raises(Exception):
+            decrypt_text("not_base64!!!", dek)
+
+
+class TestEncryptJsonValue:
+    def test_roundtrip_dict(self, dek):
+        value = {"a": 1, "b": "two", "c": None}
+        assert decrypt_json_value(encrypt_json_value(value, dek), dek) == value
+
+    def test_roundtrip_list(self, dek):
+        value = [1, "two", {"three": 3}, None, True, False]
+        assert decrypt_json_value(encrypt_json_value(value, dek), dek) == value
+
+    def test_roundtrip_nested(self, dek):
+        value = {"outer": {"inner": {"deep": [1, 2, {"x": "y"}]}}}
+        assert decrypt_json_value(encrypt_json_value(value, dek), dek) == value
+
+    def test_roundtrip_empty_dict(self, dek):
+        assert decrypt_json_value(encrypt_json_value({}, dek), dek) == {}
+
+    def test_roundtrip_empty_list(self, dek):
+        assert decrypt_json_value(encrypt_json_value([], dek), dek) == []
+
+    def test_roundtrip_unicode_keys_and_values(self, dek):
+        value = {"日本語キー": "🌸value", "emoji": "🎉"}
+        assert decrypt_json_value(encrypt_json_value(value, dek), dek) == value
+
+    def test_roundtrip_json_containing_marker_like_string(self, dek):
+        value = {"name": "owenc:v1:my-file.png"}
+        assert decrypt_json_value(encrypt_json_value(value, dek), dek) == value
+
+    def test_top_level_none_passes_through_on_encrypt(self, dek):
+        assert encrypt_json_value(None, dek) is None
+
+    def test_top_level_none_passes_through_on_decrypt(self, dek):
+        assert decrypt_json_value(None, dek) is None
+
+    def test_scalar_values_roundtrip(self, dek):
+        for value in (True, False, 0, 1, -1, 3.14, "scalar string"):
+            assert decrypt_json_value(encrypt_json_value(value, dek), dek) == value
+
+    def test_wrong_dek_raises(self, dek):
+        encrypted = encrypt_json_value({"a": 1}, dek)
+        with pytest.raises(InvalidTag):
+            decrypt_json_value(encrypted, generate_dek())
+
+    def test_tampered_ciphertext_raises(self, dek):
+        encrypted = encrypt_json_value({"a": 1}, dek)
+        raw = bytearray(base64.b64decode(encrypted))
+        raw[-1] ^= 0x01
+        tampered = base64.b64encode(bytes(raw)).decode("ascii")
+        with pytest.raises(InvalidTag):
+            decrypt_json_value(tampered, dek)
+
+    def test_non_json_serializable_raises(self, dek):
+        with pytest.raises(TypeError):
+            encrypt_json_value({"bytes": b"raw"}, dek)

--- a/backend/open_webui/utils/crypto_context.py
+++ b/backend/open_webui/utils/crypto_context.py
@@ -63,6 +63,13 @@ def get_cached_dek(user_id: str) -> Optional[bytes]:
         return dek
 
 
+def require_cached_dek(user_id: str) -> bytes:
+    dek = get_cached_dek(user_id)
+    if dek is None:
+        raise RuntimeError(f"No DEK cached for user {user_id}. User must re-login.")
+    return dek
+
+
 def remove_session(user_id: str, jti: str) -> None:
     with _cache_lock:
         entry = _dek_cache.get(user_id)

--- a/backend/open_webui/utils/crypto_utils.py
+++ b/backend/open_webui/utils/crypto_utils.py
@@ -2,7 +2,7 @@ import os
 import base64
 import json
 import logging
-from typing import Optional
+from typing import Any, Optional
 
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 from argon2.low_level import hash_secret_raw, Type
@@ -66,3 +66,35 @@ def decrypt_value(encrypted_bytes: bytes, dek: bytes) -> bytes:
     ciphertext = encrypted_bytes[NONCE_SIZE:]
     aesgcm = AESGCM(dek)
     return aesgcm.decrypt(nonce, ciphertext, None)
+
+
+def encrypt_text(value: Optional[str], dek: bytes) -> Optional[str]:
+    if value is None:
+        return None
+    encrypted = encrypt_value(value.encode("utf-8"), dek)
+    return base64.b64encode(encrypted).decode("ascii")
+
+
+def decrypt_text(value: Optional[str], dek: bytes) -> Optional[str]:
+    if value is None:
+        return None
+    encrypted = base64.b64decode(value)
+    return decrypt_value(encrypted, dek).decode("utf-8")
+
+
+def encrypt_json_value(value: Any, dek: bytes) -> Optional[str]:
+    if value is None:
+        return None
+    plaintext = json.dumps(value, ensure_ascii=False, separators=(",", ":")).encode(
+        "utf-8"
+    )
+    encrypted = encrypt_value(plaintext, dek)
+    return base64.b64encode(encrypted).decode("ascii")
+
+
+def decrypt_json_value(value: Optional[str], dek: bytes) -> Any:
+    if value is None:
+        return None
+    encrypted = base64.b64decode(value)
+    plaintext = decrypt_value(encrypted, dek)
+    return json.loads(plaintext.decode("utf-8"))


### PR DESCRIPTION
## Summary

ファイル本体・メタデータ暗号化（後続 PR で実装）の土台として、カラム単位の暗号化ヘルパと DEK 必須化ヘルパを追加します。

設計方針は `chat_hooks` と同じ **常時暗号化・常時復号** です。「すでに暗号化済か」のフォーマット判定（prefix マーカ等）は導入しません。ユーザー入力で marker 風の文字列を偽装する経路を構造的に排除するためです。

`None` は pass-through で、NULLable な JSON/Text カラムの SQL NULL セマンティクスを保ったまま暗号化できます。

## Changes

- `utils/crypto_utils.py`
  - `encrypt_text` / `decrypt_text`: `Column(Text)` 用の AES-GCM + base64 ラッパ
  - `encrypt_json_value` / `decrypt_json_value`: `Column(JSON)` 用に `json.dumps` / `json.loads` を挟んだ版。`ensure_ascii=False` と compact separators で短く保存
  - いずれも `value is None -> None` を pass-through
  - 暗号化済み判定用の prefix は導入しない
- `utils/crypto_context.py`
  - `require_cached_dek(user_id)`: `get_cached_dek` の non-Optional 版。cache miss で `RuntimeError`。暗号化フックなど DEK 必須経路向け
- テスト
  - `test/util/test_crypto_utils.py`: roundtrip（ascii / 空 / unicode / 100KB）/ None pass-through / nonce が毎回違うこと / 別 DEK で `InvalidTag` / 改ざんで `InvalidTag` / 不正 base64 / 非 JSON 入力で `TypeError`
  - marker 風の文字列（例: `owenc:v1:my-file.png`）も通常の平文として text/json helper で roundtrip できること
  - `test/util/test_crypto_context.py`: cached 取得 / 未登録 `RuntimeError` / 全 session 期限切れ / `remove_session` 後

## How to test

リポジトリルートから:

```powershell
$env:PYTHONPATH='backend'; python -m pytest backend/open_webui/test/util/test_crypto_utils.py backend/open_webui/test/util/test_crypto_context.py
```

確認済み:

```text
$env:PYTHONPATH='backend'; python -m pytest backend/open_webui/test/util/test_crypto_utils.py
25 passed
```

このヘルパ自体はまだ後続 PR から使う前提なので、この PR 単体では既存の動作には影響しません。