### PR TITLE
feat(crypto): add chunked AES-GCM file encryption primitives

### DIFF
--- a/backend/open_webui/test/util/test_crypto_utils_stream.py
+++ b/backend/open_webui/test/util/test_crypto_utils_stream.py
@@ -1,0 +1,256 @@
+import io
+import os
+
+import pytest
+from cryptography.exceptions import InvalidTag
+
+from open_webui.utils.crypto_utils import (
+    FILE_CHUNK_SIZE,
+    FILE_MAGIC,
+    NONCE_SIZE,
+    generate_dek,
+    iter_decrypt_file,
+    stream_decrypt_file_to_path,
+    stream_encrypt_file,
+)
+
+
+@pytest.fixture
+def dek() -> bytes:
+    return generate_dek()
+
+
+def _encrypt(plaintext: bytes, dek: bytes, dst, *, user_id="u1", file_id="f1", chunk_size=16) -> int:
+    return stream_encrypt_file(
+        io.BytesIO(plaintext),
+        dst,
+        dek,
+        user_id=user_id,
+        file_id=file_id,
+        chunk_size=chunk_size,
+    )
+
+
+def _decrypt_to_bytes(src, dek: bytes, *, user_id="u1", file_id="f1") -> bytes:
+    return b"".join(iter_decrypt_file(src, dek, user_id=user_id, file_id=file_id))
+
+
+class TestRoundtrip:
+    @pytest.mark.parametrize(
+        "size",
+        [
+            0,           # empty
+            1,           # tiny
+            15,          # less than chunk_size (=16 in tests)
+            16,          # exactly chunk_size
+            17,          # chunk_size + 1
+            32,          # exactly 2*chunk_size
+            33,          # 2*chunk_size + 1
+            1024,        # many chunks
+        ],
+    )
+    def test_roundtrip_to_path(self, dek, tmp_path, size):
+        plaintext = os.urandom(size)
+        encrypted = tmp_path / "enc.bin"
+        decrypted = tmp_path / "dec.bin"
+
+        written = _encrypt(plaintext, dek, encrypted)
+        assert written == size
+
+        read = stream_decrypt_file_to_path(
+            encrypted, decrypted, dek, user_id="u1", file_id="f1"
+        )
+        assert read == size
+        assert decrypted.read_bytes() == plaintext
+
+    def test_iter_decrypt_yields_full_plaintext(self, dek, tmp_path):
+        plaintext = os.urandom(40)
+        encrypted = tmp_path / "enc.bin"
+        _encrypt(plaintext, dek, encrypted)
+
+        assert _decrypt_to_bytes(encrypted, dek) == plaintext
+
+    def test_default_chunk_size_used_when_not_specified(self, dek, tmp_path):
+        # Use the production chunk size (64 KiB) so one chunk holds the whole payload.
+        plaintext = b"x" * (FILE_CHUNK_SIZE - 1)
+        encrypted = tmp_path / "enc.bin"
+        stream_encrypt_file(
+            io.BytesIO(plaintext), encrypted, dek, user_id="u1", file_id="f1"
+        )
+        assert _decrypt_to_bytes(encrypted, dek) == plaintext
+
+    def test_file_starts_with_magic(self, dek, tmp_path):
+        encrypted = tmp_path / "enc.bin"
+        _encrypt(b"abc", dek, encrypted)
+        assert encrypted.read_bytes().startswith(FILE_MAGIC)
+
+    def test_nonce_is_fresh_per_chunk(self, dek, tmp_path):
+        # Encrypt the same byte pattern twice; the on-disk bytes must differ.
+        plaintext = b"a" * 100
+        f1 = tmp_path / "1.bin"
+        f2 = tmp_path / "2.bin"
+        _encrypt(plaintext, dek, f1)
+        _encrypt(plaintext, dek, f2)
+        assert f1.read_bytes() != f2.read_bytes()
+
+
+class TestTamperDetection:
+    def test_wrong_dek_raises(self, dek, tmp_path):
+        encrypted = tmp_path / "enc.bin"
+        _encrypt(b"hello world", dek, encrypted)
+
+        with pytest.raises(InvalidTag):
+            _decrypt_to_bytes(encrypted, generate_dek())
+
+    def test_wrong_user_id_raises(self, dek, tmp_path):
+        encrypted = tmp_path / "enc.bin"
+        _encrypt(b"hello world", dek, encrypted, user_id="alice")
+
+        with pytest.raises(InvalidTag):
+            _decrypt_to_bytes(encrypted, dek, user_id="bob")
+
+    def test_wrong_file_id_raises(self, dek, tmp_path):
+        encrypted = tmp_path / "enc.bin"
+        _encrypt(b"hello world", dek, encrypted, file_id="f1")
+
+        with pytest.raises(InvalidTag):
+            _decrypt_to_bytes(encrypted, dek, file_id="f2")
+
+    def test_bad_magic_raises(self, dek, tmp_path):
+        encrypted = tmp_path / "enc.bin"
+        _encrypt(b"hello world", dek, encrypted)
+        raw = bytearray(encrypted.read_bytes())
+        raw[0] ^= 0x01
+        encrypted.write_bytes(bytes(raw))
+
+        with pytest.raises(ValueError, match="bad magic"):
+            _decrypt_to_bytes(encrypted, dek)
+
+    def test_single_bit_flip_in_ciphertext_raises(self, dek, tmp_path):
+        encrypted = tmp_path / "enc.bin"
+        _encrypt(b"hello world", dek, encrypted)
+        raw = bytearray(encrypted.read_bytes())
+        # Flip the last byte (part of the GCM tag).
+        raw[-1] ^= 0x01
+        encrypted.write_bytes(bytes(raw))
+
+        with pytest.raises(InvalidTag):
+            _decrypt_to_bytes(encrypted, dek)
+
+    def test_bad_non_final_flag_raises(self, dek, tmp_path):
+        encrypted = tmp_path / "enc.bin"
+        _encrypt(b"A" * 32, dek, encrypted, chunk_size=16)
+        raw = bytearray(encrypted.read_bytes())
+        first_flag_offset = len(FILE_MAGIC) + 4
+        raw[first_flag_offset] = 2
+        encrypted.write_bytes(bytes(raw))
+
+        with pytest.raises(ValueError, match="bad final flag"):
+            _decrypt_to_bytes(encrypted, dek)
+
+    def test_truncated_after_non_final_chunk_raises(self, dek, tmp_path):
+        # Three chunks of 16 bytes → write only the first.
+        plaintext = b"A" * 16 + b"B" * 16 + b"C" * 16
+        encrypted = tmp_path / "enc.bin"
+        _encrypt(plaintext, dek, encrypted, chunk_size=16)
+
+        raw = encrypted.read_bytes()
+        # Locate the second chunk header and truncate the file there.
+        first_chunk_size = (
+            len(FILE_MAGIC) + 4 + 1 + NONCE_SIZE + (16 + 16)  # 16 plaintext + 16 GCM tag
+        )
+        encrypted.write_bytes(raw[:first_chunk_size])
+
+        with pytest.raises(ValueError, match="missing final chunk"):
+            _decrypt_to_bytes(encrypted, dek)
+
+    def test_truncated_mid_chunk_raises(self, dek, tmp_path):
+        encrypted = tmp_path / "enc.bin"
+        _encrypt(b"ABCDEFGHIJ" * 10, dek, encrypted, chunk_size=16)
+        raw = encrypted.read_bytes()
+        # Drop the last 4 bytes (truncates the tail of the final chunk).
+        encrypted.write_bytes(raw[:-4])
+
+        with pytest.raises(ValueError):
+            _decrypt_to_bytes(encrypted, dek)
+
+    def test_trailing_garbage_after_final_chunk_raises(self, dek, tmp_path):
+        encrypted = tmp_path / "enc.bin"
+        _encrypt(b"hello", dek, encrypted)
+        raw = encrypted.read_bytes()
+        encrypted.write_bytes(raw + b"junk")
+
+        with pytest.raises(ValueError, match="after final"):
+            _decrypt_to_bytes(encrypted, dek)
+
+
+class TestErrorCleanup:
+    def test_rejects_non_positive_chunk_size(self, dek, tmp_path):
+        encrypted = tmp_path / "enc.bin"
+
+        with pytest.raises(ValueError, match="chunk_size"):
+            stream_encrypt_file(
+                io.BytesIO(b"hello"),
+                encrypted,
+                dek,
+                user_id="u1",
+                file_id="f1",
+                chunk_size=0,
+            )
+
+        assert not encrypted.exists()
+
+    def test_destination_removed_on_encrypt_failure(self, dek, tmp_path):
+        encrypted = tmp_path / "enc.bin"
+
+        class _Boom(io.BytesIO):
+            def read(self, *_args, **_kwargs):
+                raise IOError("source unreadable")
+
+        with pytest.raises(IOError):
+            stream_encrypt_file(
+                _Boom(), encrypted, dek, user_id="u1", file_id="f1", chunk_size=16
+            )
+
+        assert not encrypted.exists()
+
+    def test_destination_removed_on_decrypt_failure(self, dek, tmp_path):
+        encrypted = tmp_path / "enc.bin"
+        _encrypt(b"hello", dek, encrypted)
+        # Corrupt the tag so decryption fails after the file is opened.
+        raw = bytearray(encrypted.read_bytes())
+        raw[-1] ^= 0x01
+        encrypted.write_bytes(bytes(raw))
+
+        decrypted = tmp_path / "out" / "dec.bin"
+        with pytest.raises(InvalidTag):
+            stream_decrypt_file_to_path(
+                encrypted, decrypted, dek, user_id="u1", file_id="f1"
+            )
+
+        assert not decrypted.exists()
+
+
+class TestPathHandling:
+    def test_encrypt_creates_parent_directory(self, dek, tmp_path):
+        target = tmp_path / "a" / "b" / "c" / "enc.bin"
+        _encrypt(b"hello", dek, target)
+        assert target.exists()
+
+    def test_decrypt_creates_parent_directory(self, dek, tmp_path):
+        encrypted = tmp_path / "enc.bin"
+        _encrypt(b"hello", dek, encrypted)
+        target = tmp_path / "x" / "y" / "dec.bin"
+        stream_decrypt_file_to_path(
+            encrypted, target, dek, user_id="u1", file_id="f1"
+        )
+        assert target.read_bytes() == b"hello"
+
+    def test_accepts_str_paths(self, dek, tmp_path):
+        encrypted = str(tmp_path / "enc.bin")
+        decrypted = str(tmp_path / "dec.bin")
+        _encrypt(b"hello", dek, encrypted)
+        stream_decrypt_file_to_path(
+            encrypted, decrypted, dek, user_id="u1", file_id="f1"
+        )
+        assert open(decrypted, "rb").read() == b"hello"

--- a/backend/open_webui/utils/crypto_utils.py
+++ b/backend/open_webui/utils/crypto_utils.py
@@ -2,7 +2,9 @@ import os
 import base64
 import json
 import logging
-from typing import Any, Optional
+import struct
+from pathlib import Path
+from typing import Any, BinaryIO, Iterator, Optional
 
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 from argon2.low_level import hash_secret_raw, Type
@@ -18,6 +20,11 @@ ARGON2_TIME_COST = 1
 ARGON2_MEMORY_COST = 2097152  # 2 GiB
 ARGON2_PARALLELISM = 4
 ARGON2_HASH_LEN = 32  # 256 bits
+
+# Chunked file encryption format
+FILE_MAGIC = b"OWUIFILEENC1\n"
+FILE_CHUNK_SIZE = 64 * 1024  # 64 KiB plaintext per chunk
+_CHUNK_LEN_HEADER = struct.Struct(">I")  # 4-byte big-endian ciphertext length
 
 
 def generate_dek() -> bytes:
@@ -98,3 +105,170 @@ def decrypt_json_value(value: Optional[str], dek: bytes) -> Any:
     encrypted = base64.b64decode(value)
     plaintext = decrypt_value(encrypted, dek)
     return json.loads(plaintext.decode("utf-8"))
+
+
+# ---------------------------------------------------------------------------
+# Chunked file encryption
+#
+# File layout:
+#   [FILE_MAGIC]
+#   <chunk>+
+#
+# Per chunk:
+#   [4-byte BE ciphertext length][1-byte final flag][12-byte nonce][ciphertext]
+#
+# AAD per chunk binds user_id, file_id, chunk_index, and the final flag, so
+# truncation, reordering, and cross-file/user swap all fail at the GCM tag
+# check. An empty input still produces one final chunk with 0-byte plaintext.
+# ---------------------------------------------------------------------------
+
+
+def _file_aad(user_id: str, file_id: str, chunk_index: int, final: bool) -> bytes:
+    return f"owui-file-v1:{user_id}:{file_id}:{chunk_index}:{int(final)}".encode(
+        "utf-8"
+    )
+
+
+def stream_encrypt_file(
+    source: BinaryIO,
+    destination_path: str | Path,
+    dek: bytes,
+    *,
+    user_id: str,
+    file_id: str,
+    chunk_size: int = FILE_CHUNK_SIZE,
+) -> int:
+    """Encrypt `source` into `destination_path` in chunks. Returns plaintext byte count."""
+    if chunk_size <= 0:
+        raise ValueError("chunk_size must be greater than 0")
+
+    destination_path = Path(destination_path)
+    destination_path.parent.mkdir(parents=True, exist_ok=True)
+    aesgcm = AESGCM(dek)
+    total_size = 0
+    chunk_index = 0
+
+    try:
+        with destination_path.open("wb") as output:
+            output.write(FILE_MAGIC)
+            current = source.read(chunk_size)
+            while True:
+                next_chunk = source.read(chunk_size)
+                final = next_chunk == b""
+                nonce = os.urandom(NONCE_SIZE)
+                ciphertext = aesgcm.encrypt(
+                    nonce,
+                    current,
+                    _file_aad(user_id, file_id, chunk_index, final),
+                )
+                output.write(_CHUNK_LEN_HEADER.pack(len(ciphertext)))
+                output.write(bytes([1 if final else 0]))
+                output.write(nonce)
+                output.write(ciphertext)
+                total_size += len(current)
+                if final:
+                    break
+                current = next_chunk
+                chunk_index += 1
+    except Exception:
+        try:
+            destination_path.unlink(missing_ok=True)
+        except Exception:
+            pass
+        raise
+
+    return total_size
+
+
+def _read_exact(source: BinaryIO, n: int) -> bytes:
+    data = source.read(n)
+    if len(data) != n:
+        raise ValueError("Invalid encrypted file: unexpected EOF")
+    return data
+
+
+def _iter_chunks(
+    source: BinaryIO, dek: bytes, *, user_id: str, file_id: str
+) -> Iterator[bytes]:
+    if source.read(len(FILE_MAGIC)) != FILE_MAGIC:
+        raise ValueError("Invalid encrypted file: bad magic header")
+
+    aesgcm = AESGCM(dek)
+    chunk_index = 0
+    saw_final = False
+
+    while True:
+        length_bytes = source.read(_CHUNK_LEN_HEADER.size)
+        if length_bytes == b"":
+            break
+        if len(length_bytes) != _CHUNK_LEN_HEADER.size:
+            raise ValueError("Invalid encrypted file: truncated chunk header")
+
+        ciphertext_len = _CHUNK_LEN_HEADER.unpack(length_bytes)[0]
+        final_flag = _read_exact(source, 1)
+        if final_flag not in (b"\x00", b"\x01"):
+            raise ValueError("Invalid encrypted file: bad final flag")
+        nonce = _read_exact(source, NONCE_SIZE)
+        ciphertext = _read_exact(source, ciphertext_len)
+
+        final = final_flag == b"\x01"
+        plaintext = aesgcm.decrypt(
+            nonce,
+            ciphertext,
+            _file_aad(user_id, file_id, chunk_index, final),
+        )
+        yield plaintext
+
+        if final:
+            if source.read(1) != b"":
+                raise ValueError("Unexpected data after final encrypted chunk")
+            saw_final = True
+            break
+        chunk_index += 1
+
+    if not saw_final:
+        raise ValueError("Encrypted file is missing final chunk")
+
+
+def stream_decrypt_file_to_path(
+    source_path: str | Path,
+    destination_path: str | Path,
+    dek: bytes,
+    *,
+    user_id: str,
+    file_id: str,
+) -> int:
+    """Decrypt `source_path` into `destination_path`. Returns plaintext byte count."""
+    source_path = Path(source_path)
+    destination_path = Path(destination_path)
+    destination_path.parent.mkdir(parents=True, exist_ok=True)
+    total_size = 0
+
+    try:
+        with source_path.open("rb") as source, destination_path.open("wb") as output:
+            for plaintext in _iter_chunks(
+                source, dek, user_id=user_id, file_id=file_id
+            ):
+                output.write(plaintext)
+                total_size += len(plaintext)
+    except Exception:
+        try:
+            destination_path.unlink(missing_ok=True)
+        except Exception:
+            pass
+        raise
+
+    return total_size
+
+
+def iter_decrypt_file(
+    source_path: str | Path,
+    dek: bytes,
+    *,
+    user_id: str,
+    file_id: str,
+) -> Iterator[bytes]:
+    """Yield decrypted plaintext chunks from `source_path`."""
+    source_path = Path(source_path)
+    with source_path.open("rb") as source:
+        yield from _iter_chunks(source, dek, user_id=user_id, file_id=file_id)


### PR DESCRIPTION
> **Stacked on top of #34.** Base branch is `za/file-column-encryption` so the file encryption work is reviewed in the agreed order: #32 -> #34 -> #33 -> upload/download wiring.

## Summary

ファイル本体の暗号化に使う chunked AES-GCM プリミティブを追加します。後続 PR でアップロード/ダウンロード経路から呼び出すための土台です。

設計のポイント:

- **チャンク単位の AEAD**: 任意サイズのファイルを 64 KiB チャンクに分け、各チャンクを個別の nonce + GCM タグで暗号化。逐次書き込み・逐次読み出しが可能なのでメモリにフルロードしません。
- **AAD で `user_id` / `file_id` / `chunk_index` / `final` フラグを bind**: チャンク並べ替え・別ファイルやユーザーの暗号文すり替え・末尾欠落・偽の `final` 主張が GCM タグ検査またはフォーマット検査で失敗します。
- **空ファイル対応**: 0 バイト入力でも、`final=True` の 1 チャンク（プレーンテキスト 0 バイト + 16 バイトタグ）として書き出します。空のアップロードを上位レイヤで拒否する場合は別途 policy として実装してください。
- **エラー時クリーンアップ**: 暗号化/復号の途中で例外が出たら出力ファイルを削除。中途半端なファイルが残りません。
- **入力検証**: `chunk_size <= 0` は拒否し、復号時の `final` flag は `0` / `1` のみ許可します。

## Changes

`utils/crypto_utils.py`:

- 定数: `FILE_MAGIC`（OpenWebUI 暗号化ファイルの magic header）, `FILE_CHUNK_SIZE` (64 KiB)
- 内部ヘルパ: `_file_aad`, `_iter_chunks`, `_read_exact`
- 公開 API:
  - `stream_encrypt_file(source, destination_path, dek, *, user_id, file_id, chunk_size=...) -> int` — プレーンテキスト byte 数を返す
  - `stream_decrypt_file_to_path(source_path, destination_path, dek, *, user_id, file_id) -> int` — 一時ファイル経路（RAG/STT loader が path 入力を要求するケース向け）
  - `iter_decrypt_file(source_path, dek, *, user_id, file_id) -> Iterator[bytes]` — ストリーミング応答経路向け

ファイルレイアウト:

```text
[MAGIC (13B)]
<chunk>+
  [4-byte BE ciphertext length][1-byte final flag][12-byte nonce][ciphertext + 16-byte tag]
```

## How to test

```sh
cd backend
WEBUI_SECRET_KEY=test python -m pytest open_webui/test/util/test_crypto_utils_stream.py open_webui/test/util/test_crypto_utils.py open_webui/test/util/test_crypto_context.py -v
```

確認済み（Docker / Python 3.11.14）:

```text
57 passed
```

テストは以下をカバーしています:

- **Roundtrip**: 0 byte / 1 / chunk_size - 1 / chunk_size / chunk_size + 1 / 2×chunk_size / 2×chunk_size + 1 / 1024 byte（chunk_size=16 をテスト用に使用、`FILE_CHUNK_SIZE` のデフォルトでも別途検証）
- **Format**: 暗号化ファイル先頭の MAGIC / nonce が毎回変わること
- **改ざん検知**: 別 DEK / 別 user_id / 別 file_id / 暗号文または GCM tag の 1 ビット反転 → `InvalidTag`、MAGIC 破壊 / 末尾 truncation / 中途 truncation / 末尾ガーベジ / 不正な final flag → `ValueError`
- **入力検証**: `chunk_size <= 0` を拒否すること
- **エラー時クリーンアップ**: 暗号化失敗・復号失敗時に destination ファイルが残らないこと
- **Path 取り扱い**: 親ディレクトリ自動作成、`str` / `Path` どちらも受理

このプリミティブ自体はまだ upload/download 経路から呼ばれていないので、既存の動作には影響しません。