### PR TITLE
feat(files): transparent column encryption for filename, data, and meta

### DIFF
--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -61,7 +61,9 @@ from open_webui.utils import logger
 from open_webui.utils.audit import AuditLevel, AuditLoggingMiddleware
 from open_webui.utils.logger import start_logger
 from open_webui.utils.memory_lock import enable_memory_lock
-import open_webui.utils.chat_hooks  # noqa: F401 — registers SQLAlchemy event listeners
+# Register SQLAlchemy encryption event listeners.
+import open_webui.utils.chat_hooks  # noqa: F401
+import open_webui.utils.file_hooks  # noqa: F401
 from open_webui.socket.main import (
     MODELS,
     app as socket_app,

--- a/backend/open_webui/models/files.py
+++ b/backend/open_webui/models/files.py
@@ -1,3 +1,4 @@
+import fnmatch
 import logging
 import time
 from typing import Optional
@@ -216,9 +217,7 @@ class FilesTable:
                     created_at=file.created_at,
                     updated_at=file.updated_at,
                 )
-                for file in db.query(
-                    File.id, File.hash, File.meta, File.created_at, File.updated_at
-                )
+                for file in db.query(File)
                 .filter(File.id.in_(ids))
                 .order_by(File.updated_at.desc())
                 .all()
@@ -233,29 +232,6 @@ class FilesTable:
                 for file in db.query(File).filter_by(user_id=user_id).all()
             ]
 
-    @staticmethod
-    def _glob_to_like_pattern(glob: str) -> str:
-        """
-        Convert a glob/fnmatch pattern to a SQL LIKE pattern.
-
-        Escapes SQL special characters and converts glob wildcards:
-        - `*` becomes `%` (match any sequence of characters)
-        - `?` becomes `_` (match exactly one character)
-
-        Args:
-            glob: A glob pattern (e.g., "*.txt", "file?.doc")
-
-        Returns:
-            A SQL LIKE compatible pattern with proper escaping.
-        """
-        # Escape SQL special characters first, then convert glob wildcards
-        pattern = glob.replace("\\", "\\\\")
-        pattern = pattern.replace("%", "\\%")
-        pattern = pattern.replace("_", "\\_")
-        pattern = pattern.replace("*", "%")
-        pattern = pattern.replace("?", "_")
-        return pattern
-
     def search_files(
         self,
         user_id: Optional[str] = None,
@@ -266,6 +242,9 @@ class FilesTable:
     ) -> list[FileModel]:
         """
         Search files with glob pattern matching, optional user filter, and pagination.
+
+        Filename is encrypted at the column level, so the pattern match runs
+        in Python after the load hook has decrypted each row.
 
         Args:
             user_id: Filter by user ID. If None, returns files for all users.
@@ -279,20 +258,20 @@ class FilesTable:
         """
         with get_db_context(db) as db:
             query = db.query(File)
-
             if user_id:
                 query = query.filter_by(user_id=user_id)
 
-            pattern = self._glob_to_like_pattern(filename)
-            if pattern != "%":
-                query = query.filter(File.filename.ilike(pattern, escape="\\"))
+            files = query.order_by(File.updated_at.desc()).all()
+            if filename != "*":
+                pattern = filename.lower()
+                files = [
+                    file
+                    for file in files
+                    if fnmatch.fnmatch((file.filename or "").lower(), pattern)
+                ]
 
             return [
-                FileModel.model_validate(file)
-                for file in query.order_by(File.updated_at.desc())
-                .offset(skip)
-                .limit(limit)
-                .all()
+                FileModel.model_validate(file) for file in files[skip : skip + limit]
             ]
 
     def update_file_by_id(

--- a/backend/open_webui/test/util/test_file_hooks.py
+++ b/backend/open_webui/test/util/test_file_hooks.py
@@ -1,0 +1,206 @@
+import time
+
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker
+
+from open_webui.internal.db import Base
+from open_webui.models.files import File
+from open_webui.utils import crypto_context
+from open_webui.utils.crypto_context import cache_dek
+from open_webui.utils.crypto_utils import (
+    decrypt_json_value,
+    decrypt_text,
+    generate_dek,
+)
+
+# Importing this module registers the SQLAlchemy event listeners globally
+# for the File model. All File operations in this test module then go
+# through the encryption hooks.
+import open_webui.utils.file_hooks  # noqa: F401
+
+
+USER_ID = "test-user"
+
+
+@pytest.fixture
+def dek() -> bytes:
+    key = generate_dek()
+    cache_dek(USER_ID, key, jti="test-jti", expires_at=time.time() + 3600)
+    yield key
+    crypto_context._dek_cache.clear()
+
+
+@pytest.fixture
+def db():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine, tables=[File.__table__])
+    SessionLocal = sessionmaker(bind=engine)
+    session = SessionLocal()
+    yield session
+    session.close()
+    engine.dispose()
+
+
+def _raw_row(db, file_id):
+    row = db.execute(
+        text("SELECT filename, data, meta FROM file WHERE id = :id"),
+        {"id": file_id},
+    ).first()
+    return row  # (filename, data, meta) as raw SQL — no ORM event
+
+
+def _make_file(file_id="f1", filename="report.pdf"):
+    now = int(time.time())
+    return File(
+        id=file_id,
+        user_id=USER_ID,
+        filename=filename,
+        path=f"/uploads/{file_id}",
+        data={"status": "pending"},
+        meta={"name": filename, "size": 1234},
+        created_at=now,
+        updated_at=now,
+    )
+
+
+class TestInsertEncryption:
+    def test_filename_stored_as_ciphertext(self, db, dek):
+        db.add(_make_file())
+        db.commit()
+
+        raw = _raw_row(db, "f1")
+        assert raw is not None
+        assert raw[0] != "report.pdf"
+        assert "report" not in raw[0]
+        # Sanity: decrypting the raw value with the test DEK returns the plaintext.
+        assert decrypt_text(raw[0], dek) == "report.pdf"
+
+    def test_data_stored_as_ciphertext(self, db, dek):
+        db.add(_make_file())
+        db.commit()
+
+        raw = _raw_row(db, "f1")
+        # JSON column is serialized as JSON-string of an encrypted base64 string.
+        assert "pending" not in raw[1]
+        # Strip the json.dumps surrounding quotes before decrypting.
+        assert decrypt_json_value(raw[1].strip('"'), dek) == {"status": "pending"}
+
+    def test_meta_stored_as_ciphertext(self, db, dek):
+        db.add(_make_file())
+        db.commit()
+
+        raw = _raw_row(db, "f1")
+        assert "report.pdf" not in raw[2]
+        assert decrypt_json_value(raw[2].strip('"'), dek) == {
+            "name": "report.pdf",
+            "size": 1234,
+        }
+
+    def test_inserted_object_returns_plaintext_in_memory(self, db, dek):
+        # After commit + after_insert hook restores plaintext for in-process callers.
+        f = _make_file()
+        db.add(f)
+        db.commit()
+
+        assert f.filename == "report.pdf"
+        assert f.data == {"status": "pending"}
+        assert f.meta == {"name": "report.pdf", "size": 1234}
+
+
+class TestLoadDecryption:
+    def test_query_decrypts(self, db, dek):
+        db.add(_make_file())
+        db.commit()
+        db.expire_all()  # force reload from DB on next access
+
+        loaded = db.query(File).filter_by(id="f1").one()
+        assert loaded.filename == "report.pdf"
+        assert loaded.data == {"status": "pending"}
+        assert loaded.meta == {"name": "report.pdf", "size": 1234}
+
+    def test_db_get_decrypts(self, db, dek):
+        db.add(_make_file())
+        db.commit()
+        db.expire_all()
+
+        loaded = db.get(File, "f1")
+        assert loaded.filename == "report.pdf"
+
+
+class TestUpdateEncryption:
+    def test_update_re_encrypts(self, db, dek):
+        db.add(_make_file())
+        db.commit()
+
+        f = db.query(File).filter_by(id="f1").one()
+        f.filename = "renamed.pdf"
+        f.data = {"status": "completed", "content": "extracted text"}
+        db.commit()
+
+        raw = _raw_row(db, "f1")
+        assert "renamed" not in raw[0]
+        assert "completed" not in raw[1]
+        assert decrypt_text(raw[0], dek) == "renamed.pdf"
+        assert decrypt_json_value(raw[1].strip('"'), dek) == {
+            "status": "completed",
+            "content": "extracted text",
+        }
+
+    def test_update_then_reload_returns_new_plaintext(self, db, dek):
+        db.add(_make_file())
+        db.commit()
+
+        f = db.query(File).filter_by(id="f1").one()
+        f.filename = "renamed.pdf"
+        db.commit()
+        db.expire_all()
+
+        loaded = db.query(File).filter_by(id="f1").one()
+        assert loaded.filename == "renamed.pdf"
+
+
+class TestNoneHandling:
+    def test_null_data_and_meta_roundtrip(self, db, dek):
+        f = _make_file()
+        f.data = None
+        f.meta = None
+        db.add(f)
+        db.commit()
+
+        raw = _raw_row(db, "f1")
+        # SQLite stores JSON None as JSON null when viewed via raw SQL.
+        assert raw[1] == "null"
+        assert raw[2] == "null"
+
+        db.expire_all()
+        loaded = db.query(File).filter_by(id="f1").one()
+        assert loaded.data is None
+        assert loaded.meta is None
+
+
+class TestDekRequired:
+    def test_insert_without_dek_raises(self, db):
+        # No DEK cached for USER_ID
+        with pytest.raises(RuntimeError, match="No DEK cached"):
+            db.add(_make_file())
+            db.commit()
+
+    def test_load_without_dek_raises(self, db, dek):
+        db.add(_make_file())
+        db.commit()
+        db.expire_all()
+        crypto_context._dek_cache.clear()
+
+        with pytest.raises(RuntimeError, match="No DEK cached"):
+            db.query(File).filter_by(id="f1").one()
+
+    def test_update_without_dek_raises(self, db, dek):
+        db.add(_make_file())
+        db.commit()
+        f = db.query(File).filter_by(id="f1").one()
+        crypto_context._dek_cache.clear()
+
+        f.filename = "renamed.pdf"
+        with pytest.raises(RuntimeError, match="No DEK cached"):
+            db.commit()

--- a/backend/open_webui/test/util/test_files_search.py
+++ b/backend/open_webui/test/util/test_files_search.py
@@ -1,0 +1,109 @@
+import time
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from open_webui.internal import db as internal_db
+from open_webui.internal.db import Base
+from open_webui.models.files import File, Files
+from open_webui.utils import crypto_context
+from open_webui.utils.crypto_context import cache_dek
+from open_webui.utils.crypto_utils import generate_dek
+
+# Ensure the encryption hooks are registered before File operations run.
+import open_webui.utils.file_hooks  # noqa: F401
+
+
+USER_ID = "test-user"
+
+
+@pytest.fixture
+def db(monkeypatch):
+    monkeypatch.setattr(internal_db, "DATABASE_ENABLE_SESSION_SHARING", True)
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine, tables=[File.__table__])
+    SessionLocal = sessionmaker(bind=engine)
+    session = SessionLocal()
+    cache_dek(USER_ID, generate_dek(), jti="jti-1", expires_at=time.time() + 3600)
+    yield session
+    session.close()
+    engine.dispose()
+    crypto_context._dek_cache.clear()
+
+
+def _insert_files(db, names):
+    now = int(time.time())
+    for i, name in enumerate(names):
+        # Spread updated_at so ordering is deterministic.
+        db.add(
+            File(
+                id=f"f{i}",
+                user_id=USER_ID,
+                filename=name,
+                path=f"/uploads/f{i}",
+                data={},
+                meta={"name": name},
+                created_at=now,
+                updated_at=now + i,
+            )
+        )
+    db.commit()
+
+
+class TestSearchFiles:
+    def test_default_pattern_matches_all(self, db):
+        _insert_files(db, ["a.txt", "b.pdf", "c.md"])
+        results = Files.search_files(user_id=USER_ID, db=db)
+        assert {r.filename for r in results} == {"a.txt", "b.pdf", "c.md"}
+
+    def test_glob_extension_match(self, db):
+        _insert_files(db, ["a.txt", "b.pdf", "c.txt"])
+        results = Files.search_files(user_id=USER_ID, filename="*.txt", db=db)
+        assert {r.filename for r in results} == {"a.txt", "c.txt"}
+
+    def test_glob_single_char(self, db):
+        _insert_files(db, ["a.txt", "ab.txt", "abc.txt"])
+        results = Files.search_files(user_id=USER_ID, filename="a?.txt", db=db)
+        assert {r.filename for r in results} == {"ab.txt"}
+
+    def test_case_insensitive(self, db):
+        _insert_files(db, ["Report.PDF", "memo.pdf"])
+        results = Files.search_files(user_id=USER_ID, filename="*.pdf", db=db)
+        assert {r.filename for r in results} == {"Report.PDF", "memo.pdf"}
+
+    def test_results_ordered_by_updated_at_desc(self, db):
+        _insert_files(db, ["old.txt", "new.txt"])
+        results = Files.search_files(user_id=USER_ID, db=db)
+        # "new.txt" was inserted last (updated_at + 1).
+        assert results[0].filename == "new.txt"
+
+    def test_pagination(self, db):
+        _insert_files(db, [f"{i}.txt" for i in range(10)])
+        page1 = Files.search_files(user_id=USER_ID, skip=0, limit=3, db=db)
+        page2 = Files.search_files(user_id=USER_ID, skip=3, limit=3, db=db)
+        assert len(page1) == 3
+        assert len(page2) == 3
+        assert {f.filename for f in page1} & {f.filename for f in page2} == set()
+
+    def test_user_filter(self, db):
+        # Insert files for the test user, then add one for a different user.
+        _insert_files(db, ["mine.txt"])
+        other_dek = generate_dek()
+        cache_dek("other-user", other_dek, jti="j2", expires_at=time.time() + 3600)
+        db.add(
+            File(
+                id="other",
+                user_id="other-user",
+                filename="theirs.txt",
+                path="/uploads/other",
+                data={},
+                meta={"name": "theirs.txt"},
+                created_at=int(time.time()),
+                updated_at=int(time.time()),
+            )
+        )
+        db.commit()
+
+        results = Files.search_files(user_id=USER_ID, db=db)
+        assert {r.filename for r in results} == {"mine.txt"}

--- a/backend/open_webui/utils/file_hooks.py
+++ b/backend/open_webui/utils/file_hooks.py
@@ -1,0 +1,83 @@
+"""
+SQLAlchemy event hooks for transparent File column encryption.
+
+Encrypts filename, data, and meta on INSERT/UPDATE and decrypts on load/refresh,
+using the file owner's DEK from the in-memory cache.
+"""
+
+from sqlalchemy import event
+
+from open_webui.models.files import File
+from open_webui.utils.crypto_context import require_cached_dek
+from open_webui.utils.crypto_utils import (
+    decrypt_json_value,
+    decrypt_text,
+    encrypt_json_value,
+    encrypt_text,
+)
+
+
+def _encrypt_fields(target: File) -> None:
+    dek = require_cached_dek(target.user_id)
+
+    target._filename_plaintext = target.filename
+    target._data_plaintext = target.data
+    target._meta_plaintext = target.meta
+
+    target.filename = encrypt_text(target.filename, dek)
+    target.data = encrypt_json_value(target.data, dek)
+    target.meta = encrypt_json_value(target.meta, dek)
+
+
+def _decrypt_fields(target: File) -> None:
+    dek = require_cached_dek(target.user_id)
+
+    target.filename = decrypt_text(target.filename, dek)
+    target.data = decrypt_json_value(target.data, dek)
+    target.meta = decrypt_json_value(target.meta, dek)
+
+
+def _restore_plaintext(target: File) -> None:
+    if hasattr(target, "_filename_plaintext"):
+        target.filename = target._filename_plaintext
+        del target._filename_plaintext
+    if hasattr(target, "_data_plaintext"):
+        target.data = target._data_plaintext
+        del target._data_plaintext
+    if hasattr(target, "_meta_plaintext"):
+        target.meta = target._meta_plaintext
+        del target._meta_plaintext
+
+
+# -- Event listeners --------------------------------------------------------
+
+
+@event.listens_for(File, "before_insert")
+def on_before_insert(mapper, connection, target):
+    _encrypt_fields(target)
+
+
+@event.listens_for(File, "after_insert")
+def on_after_insert(mapper, connection, target):
+    _restore_plaintext(target)
+
+
+@event.listens_for(File, "before_update")
+def on_before_update(mapper, connection, target):
+    _encrypt_fields(target)
+
+
+@event.listens_for(File, "after_update")
+def on_after_update(mapper, connection, target):
+    _restore_plaintext(target)
+
+
+@event.listens_for(File, "load")
+def on_load(target, context):
+    _decrypt_fields(target)
+
+
+@event.listens_for(File, "refresh")
+def on_refresh(target, context, attrs):
+    if attrs is None or any(attr in attrs for attr in ("filename", "data", "meta")):
+        _decrypt_fields(target)


### PR DESCRIPTION
> **Stacked on top of #32.** Base branch is `za/crypto-text-helpers`. GitHub will auto-retarget to `main` once #32 merges.

## Summary

`File` テーブルの `filename` / `data` / `meta` カラムを SQLAlchemy event hook で透過的に暗号化・復号します。`chat_hooks` と同じパターンで、フォーマット判別なしの常時暗号化・常時復号です。

カラム暗号化に伴い、`File.filename` を対象にした SQL レベルの `ILIKE` が使えなくなるため、`Files.search_files` の filename フィルタを Python 側に移動します。検索前の一覧順は従来どおり `updated_at DESC` です。

## Changes

**新規ファイル**:

- `utils/file_hooks.py`
  - `_encrypt_fields(target)` — `target.user_id` の DEK で `filename`, `data`, `meta` を暗号化し、復元用 plaintext を `_*_plaintext` 属性に保存
  - `_decrypt_fields(target)` — 復号して in-place 書き戻し
  - `_restore_plaintext(target)` — INSERT/UPDATE 後に caller から見える属性を平文に戻す
  - イベントリスナ: `before_insert` / `after_insert` / `before_update` / `after_update` / `load` / `refresh`

**修正**:

- `main.py` — `file_hooks` を import してリスナ登録
- `models/files.py`
  - `get_file_metadatas_by_ids`: `SELECT *` に変更（カラム単独 select だと load event が発火しないため）
  - `search_files`: SQL `ILIKE` を撤廃し、`fnmatch` ベースの Python 側フィルタに変更
  - `_glob_to_like_pattern` 削除（不要になったため）

**テスト**:

- `test/util/test_file_hooks.py`
  - INSERT で raw SQL を見ると ciphertext で格納されている
  - LOAD で復号される (`db.query`, `db.get` 両方)
  - UPDATE で再暗号化される
  - `data` / `meta` の `None` が JSON null として roundtrip する
  - DEK 未キャッシュ時 INSERT/LOAD/UPDATE すべて `RuntimeError`
- `test/util/test_files_search.py`
  - デフォルト `*` で全件、`*.txt` / `a?.txt` で glob match
  - case insensitive
  - `updated_at DESC` 順、pagination、user_id フィルタ

## How to test

```sh
cd backend
WEBUI_SECRET_KEY=test python -m pytest open_webui/test/util/test_file_hooks.py open_webui/test/util/test_files_search.py -v
```

確認済み（Docker / Python 3.11.14）:

```text
19 passed, 1 warning
```

E2E:

- ファイルをアップロード → DB を直接見て `filename` / `data` / `meta` が ciphertext で保存されていることを確認
- ファイル一覧 / 検索が UI 上で従来どおり動くことを確認

## 既知の制約（後続 PR / follow-up で対応）

- **Knowledge 側の filename 参照は後続対応**: この PR は `Files` 自身の検索に範囲を絞っています。
- **共有ファイルアクセスは owner ログイン中限定**: フックは `target.user_id`（owner）の DEK で復号するため、owner が未ログイン時は `RuntimeError` → 500 になります。上位レイヤで適切な HTTP ステータスに変換する必要あり (TBD)。
- **検索の O(N) 化**: filename が SQL 不可視のため全件 load → Python filter。10k+ ファイル規模では性能影響が出ます。blind-index 等の対応は別 PR。
- **`before_update` が常に3列を dirty 化**: chat_hooks と同じ挙動（無関係カラムの更新でも再暗号化が走る）。最適化は別途検討。