### PR TITLE
feat(files): wire encrypted file bodies into upload and download

### DIFF
--- a/backend/open_webui/crypto_exceptions.py
+++ b/backend/open_webui/crypto_exceptions.py
@@ -1,0 +1,2 @@
+class EncryptedDataAccessDeniedError(RuntimeError):
+    pass

--- a/backend/open_webui/models/files.py
+++ b/backend/open_webui/models/files.py
@@ -178,9 +178,12 @@ class FilesTable:
             except Exception:
                 return None
 
-    def get_files(self, db: Optional[Session] = None) -> list[FileModel]:
+    def get_file_hash_by_id(self, id: str, db: Optional[Session] = None) -> Optional[str]:
         with get_db_context(db) as db:
-            return [FileModel.model_validate(file) for file in db.query(File).all()]
+            try:
+                return db.query(File.hash).filter_by(id=id).scalar()
+            except Exception:
+                return None
 
     def check_access_by_user_id(
         self, id, user_id, permission="write", db: Optional[Session] = None

--- a/backend/open_webui/routers/files.py
+++ b/backend/open_webui/routers/files.py
@@ -2,7 +2,6 @@ import logging
 import os
 import uuid
 import json
-from pathlib import Path
 from typing import Optional
 from urllib.parse import quote
 import asyncio
@@ -20,7 +19,7 @@ from fastapi import (
     Query,
 )
 
-from fastapi.responses import FileResponse, StreamingResponse
+from fastapi.responses import StreamingResponse
 from sqlalchemy.orm import Session
 from open_webui.internal.db import get_session, SessionLocal
 
@@ -48,12 +47,26 @@ from open_webui.storage.provider import Storage
 
 from open_webui.utils.auth import get_admin_user, get_verified_user
 from open_webui.utils.access_control import has_access
+from open_webui.utils.file_crypto import (
+    DecryptedFileResponse,
+    decrypted_file_path,
+    store_encrypted_upload,
+)
 from open_webui.utils.misc import strict_match_mime_type
 from pydantic import BaseModel
 
 log = logging.getLogger(__name__)
 
 router = APIRouter()
+
+
+def cleanup_file_path(file_path: Optional[str]) -> None:
+    if not file_path:
+        return
+    try:
+        Storage.delete_file(file_path)
+    except Exception:
+        pass
 
 
 ############################
@@ -134,10 +147,10 @@ def process_uploaded_file(
                 if strict_match_mime_type(
                     stt_supported_content_types, file.content_type
                 ):
-                    file_path_processed = Storage.get_file(file_path)
-                    result = transcribe(
-                        request, file_path_processed, file_metadata, user
-                    )
+                    with decrypted_file_path(file_item) as file_path_processed:
+                        result = transcribe(
+                            request, file_path_processed, file_metadata, user
+                        )
 
                     process_file(
                         request,
@@ -233,6 +246,7 @@ def upload_file_handler(
                 detail=ERROR_MESSAGES.DEFAULT("Invalid metadata format"),
             )
     file_metadata = metadata if metadata else {}
+    file_path = None
 
     try:
         unsanitized_filename = file.filename
@@ -258,16 +272,10 @@ def upload_file_handler(
         # replace filename with uuid
         id = str(uuid.uuid4())
         name = filename
-        filename = f"{id}_{filename}"
-        contents, file_path = Storage.upload_file(
+        file_size, file_path = store_encrypted_upload(
             file.file,
-            filename,
-            {
-                "OpenWebUI-User-Email": user.email,
-                "OpenWebUI-User-Id": user.id,
-                "OpenWebUI-User-Name": user.name,
-                "OpenWebUI-File-Id": id,
-            },
+            user_id=user.id,
+            file_id=id,
         )
 
         file_item = Files.insert_new_file(
@@ -283,7 +291,7 @@ def upload_file_handler(
                     "meta": {
                         "name": name,
                         "content_type": file.content_type,
-                        "size": len(contents),
+                        "size": file_size,
                         "data": file_metadata,
                     },
                 }
@@ -332,8 +340,24 @@ def upload_file_handler(
                     detail=ERROR_MESSAGES.DEFAULT("Error uploading file"),
                 )
 
+    except HTTPException:
+        cleanup_file_path(file_path)
+        raise
+    except RuntimeError as e:
+        cleanup_file_path(file_path)
+        if "No DEK cached" in str(e):
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail=ERROR_MESSAGES.DEFAULT("User must re-login to upload files"),
+            )
+        log.exception(e)
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=ERROR_MESSAGES.DEFAULT("Error uploading file"),
+        )
     except Exception as e:
         log.exception(e)
+        cleanup_file_path(file_path)
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=ERROR_MESSAGES.DEFAULT("Error uploading file"),
@@ -640,44 +664,47 @@ async def get_file_content_by_id(
         or has_access_to_file(id, "read", user, db=db)
     ):
         try:
-            file_path = Storage.get_file(file.path)
-            file_path = Path(file_path)
+            filename = file.meta.get("name", file.filename)
+            encoded_filename = quote(filename)  # RFC5987 encoding
+            content_type = file.meta.get("content_type")
+            headers = {}
 
-            # Check if the file already exists in the cache
-            if file_path.is_file():
-                # Handle Unicode filenames
-                filename = file.meta.get("name", file.filename)
-                encoded_filename = quote(filename)  # RFC5987 encoding
-
-                content_type = file.meta.get("content_type")
-                filename = file.meta.get("name", file.filename)
-                encoded_filename = quote(filename)
-                headers = {}
-
-                if attachment:
+            if attachment:
+                headers["Content-Disposition"] = (
+                    f"attachment; filename*=UTF-8''{encoded_filename}"
+                )
+            else:
+                if content_type == "application/pdf" or filename.lower().endswith(
+                    ".pdf"
+                ):
+                    headers["Content-Disposition"] = (
+                        f"inline; filename*=UTF-8''{encoded_filename}"
+                    )
+                    content_type = "application/pdf"
+                elif content_type != "text/plain":
                     headers["Content-Disposition"] = (
                         f"attachment; filename*=UTF-8''{encoded_filename}"
                     )
-                else:
-                    if content_type == "application/pdf" or filename.lower().endswith(
-                        ".pdf"
-                    ):
-                        headers["Content-Disposition"] = (
-                            f"inline; filename*=UTF-8''{encoded_filename}"
-                        )
-                        content_type = "application/pdf"
-                    elif content_type != "text/plain":
-                        headers["Content-Disposition"] = (
-                            f"attachment; filename*=UTF-8''{encoded_filename}"
-                        )
 
-                return FileResponse(file_path, headers=headers, media_type=content_type)
-
-            else:
+            return DecryptedFileResponse(
+                file,
+                headers=headers,
+                media_type=content_type,
+            )
+        except FileNotFoundError:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=ERROR_MESSAGES.NOT_FOUND,
+            )
+        except RuntimeError as e:
+            if "No DEK cached" in str(e):
                 raise HTTPException(
-                    status_code=status.HTTP_404_NOT_FOUND,
-                    detail=ERROR_MESSAGES.NOT_FOUND,
+                    status_code=status.HTTP_401_UNAUTHORIZED,
+                    detail=ERROR_MESSAGES.DEFAULT(
+                        "User must re-login to access encrypted file"
+                    ),
                 )
+            raise
         except Exception as e:
             log.exception(e)
             log.error("Error getting file content")
@@ -717,18 +744,21 @@ async def get_html_file_content_by_id(
         or has_access_to_file(id, "read", user, db=db)
     ):
         try:
-            file_path = Storage.get_file(file.path)
-            file_path = Path(file_path)
-
-            # Check if the file already exists in the cache
-            if file_path.is_file():
-                log.info(f"file_path: {file_path}")
-                return FileResponse(file_path)
-            else:
+            return DecryptedFileResponse(file)
+        except FileNotFoundError:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=ERROR_MESSAGES.NOT_FOUND,
+            )
+        except RuntimeError as e:
+            if "No DEK cached" in str(e):
                 raise HTTPException(
-                    status_code=status.HTTP_404_NOT_FOUND,
-                    detail=ERROR_MESSAGES.NOT_FOUND,
+                    status_code=status.HTTP_401_UNAUTHORIZED,
+                    detail=ERROR_MESSAGES.DEFAULT(
+                        "User must re-login to access encrypted file"
+                    ),
                 )
+            raise
         except Exception as e:
             log.exception(e)
             log.error("Error getting file content")
@@ -770,17 +800,22 @@ async def get_file_content_by_id(
         }
 
         if file_path:
-            file_path = Storage.get_file(file_path)
-            file_path = Path(file_path)
-
-            # Check if the file already exists in the cache
-            if file_path.is_file():
-                return FileResponse(file_path, headers=headers)
-            else:
+            try:
+                return DecryptedFileResponse(file, headers=headers)
+            except FileNotFoundError:
                 raise HTTPException(
                     status_code=status.HTTP_404_NOT_FOUND,
                     detail=ERROR_MESSAGES.NOT_FOUND,
                 )
+            except RuntimeError as e:
+                if "No DEK cached" in str(e):
+                    raise HTTPException(
+                        status_code=status.HTTP_401_UNAUTHORIZED,
+                        detail=ERROR_MESSAGES.DEFAULT(
+                            "User must re-login to access encrypted file"
+                        ),
+                    )
+                raise
         else:
             # File path doesn’t exist, return the content as .txt if possible
             file_content = file.content.get("content", "")

--- a/backend/open_webui/routers/files.py
+++ b/backend/open_webui/routers/files.py
@@ -21,12 +21,16 @@ from fastapi import (
 
 from fastapi.responses import StreamingResponse
 from sqlalchemy.orm import Session
+from open_webui.crypto_exceptions import EncryptedDataAccessDeniedError
 from open_webui.internal.db import get_session, SessionLocal
 
 from open_webui.constants import ERROR_MESSAGES
 from open_webui.retrieval.vector.factory import VECTOR_DB_CLIENT
 
 from open_webui.models.channels import Channels
+from open_webui.models.chats import Chats
+from open_webui.models.knowledge import Knowledges
+from open_webui.models.groups import Groups
 from open_webui.models.users import Users
 from open_webui.models.files import (
     FileForm,
@@ -34,9 +38,6 @@ from open_webui.models.files import (
     FileModelResponse,
     Files,
 )
-from open_webui.models.chats import Chats
-from open_webui.models.knowledge import Knowledges
-from open_webui.models.groups import Groups
 
 
 from open_webui.routers.retrieval import ProcessFileForm, process_file
@@ -147,7 +148,9 @@ def process_uploaded_file(
                 if strict_match_mime_type(
                     stt_supported_content_types, file.content_type
                 ):
-                    with decrypted_file_path(file_item) as file_path_processed:
+                    with decrypted_file_path(
+                        file_item, user_id=user.id
+                    ) as file_path_processed:
                         result = transcribe(
                             request, file_path_processed, file_metadata, user
                         )
@@ -375,10 +378,7 @@ async def list_files(
     content: bool = Query(True),
     db: Session = Depends(get_session),
 ):
-    if user.role == "admin":
-        files = Files.get_files(db=db)
-    else:
-        files = Files.get_files_by_user_id(user.id, db=db)
+    files = Files.get_files_by_user_id(user.id, db=db)
 
     if not content:
         for file in files:
@@ -411,12 +411,8 @@ async def search_files(
     Search for files by filename with support for wildcard patterns.
     Uses SQL-based filtering with pagination for better performance.
     """
-    # Determine user_id: null for admin (search all), user.id for regular users
-    user_id = None if user.role == "admin" else user.id
-
-    # Use optimized database query with pagination
     files = Files.search_files(
-        user_id=user_id,
+        user_id=user.id,
         filename=filename,
         skip=skip,
         limit=limit,
@@ -475,7 +471,7 @@ async def delete_all_files(
 async def get_file_by_id(
     id: str, user=Depends(get_verified_user), db: Session = Depends(get_session)
 ):
-    file = Files.get_file_by_id(id, db=db)
+    file = Files.get_file_by_id_and_user_id(id, user.id, db=db)
 
     if not file:
         raise HTTPException(
@@ -483,17 +479,7 @@ async def get_file_by_id(
             detail=ERROR_MESSAGES.NOT_FOUND,
         )
 
-    if (
-        file.user_id == user.id
-        or user.role == "admin"
-        or has_access_to_file(id, "read", user, db=db)
-    ):
-        return file
-    else:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=ERROR_MESSAGES.NOT_FOUND,
-        )
+    return file
 
 
 @router.get("/{id}/process/status")
@@ -503,7 +489,7 @@ async def get_file_process_status(
     user=Depends(get_verified_user),
     db: Session = Depends(get_session),
 ):
-    file = Files.get_file_by_id(id, db=db)
+    file = Files.get_file_by_id_and_user_id(id, user.id, db=db)
 
     if not file:
         raise HTTPException(
@@ -511,52 +497,44 @@ async def get_file_process_status(
             detail=ERROR_MESSAGES.NOT_FOUND,
         )
 
-    if (
-        file.user_id == user.id
-        or user.role == "admin"
-        or has_access_to_file(id, "read", user, db=db)
-    ):
-        if stream:
-            MAX_FILE_PROCESSING_DURATION = 3600 * 2
+    if stream:
+        MAX_FILE_PROCESSING_DURATION = 3600 * 2
 
-            async def event_stream(file_id):
-                # NOTE: We intentionally do NOT capture the request's db session here.
-                # Each poll creates its own short-lived session to avoid holding a
-                # connection for hours. A WebSocket push would be more efficient.
-                for _ in range(MAX_FILE_PROCESSING_DURATION):
-                    file_item = Files.get_file_by_id(file_id)  # Creates own session
-                    if file_item:
-                        data = file_item.model_dump().get("data", {})
-                        status = data.get("status")
+        async def event_stream(file_id):
+            # NOTE: We intentionally do NOT capture the request's db session here.
+            # Each poll creates its own short-lived session to avoid holding a
+            # connection for hours. A WebSocket push would be more efficient.
+            for _ in range(MAX_FILE_PROCESSING_DURATION):
+                file_item = Files.get_file_by_id_and_user_id(
+                    file_id, user.id
+                )  # Creates own session
+                if file_item:
+                    data = file_item.model_dump().get("data", {})
+                    status = data.get("status")
 
-                        if status:
-                            event = {"status": status}
-                            if status == "failed":
-                                event["error"] = data.get("error")
+                    if status:
+                        event = {"status": status}
+                        if status == "failed":
+                            event["error"] = data.get("error")
 
-                            yield f"data: {json.dumps(event)}\n\n"
-                            if status in ("completed", "failed"):
-                                break
-                        else:
-                            # Legacy
+                        yield f"data: {json.dumps(event)}\n\n"
+                        if status in ("completed", "failed"):
                             break
                     else:
-                        yield f"data: {json.dumps({'status': 'not_found'})}\n\n"
+                        # Legacy
                         break
+                else:
+                    yield f"data: {json.dumps({'status': 'not_found'})}\n\n"
+                    break
 
-                    await asyncio.sleep(1)
+                await asyncio.sleep(1)
 
-            return StreamingResponse(
-                event_stream(file.id),
-                media_type="text/event-stream",
-            )
-        else:
-            return {"status": file.data.get("status", "pending")}
-    else:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=ERROR_MESSAGES.NOT_FOUND,
+        return StreamingResponse(
+            event_stream(file.id),
+            media_type="text/event-stream",
         )
+    else:
+        return {"status": file.data.get("status", "pending")}
 
 
 ############################
@@ -568,7 +546,7 @@ async def get_file_process_status(
 async def get_file_data_content_by_id(
     id: str, user=Depends(get_verified_user), db: Session = Depends(get_session)
 ):
-    file = Files.get_file_by_id(id, db=db)
+    file = Files.get_file_by_id_and_user_id(id, user.id, db=db)
 
     if not file:
         raise HTTPException(
@@ -576,17 +554,7 @@ async def get_file_data_content_by_id(
             detail=ERROR_MESSAGES.NOT_FOUND,
         )
 
-    if (
-        file.user_id == user.id
-        or user.role == "admin"
-        or has_access_to_file(id, "read", user, db=db)
-    ):
-        return {"content": file.data.get("content", "")}
-    else:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=ERROR_MESSAGES.NOT_FOUND,
-        )
+    return {"content": file.data.get("content", "")}
 
 
 ############################
@@ -606,7 +574,7 @@ async def update_file_data_content_by_id(
     user=Depends(get_verified_user),
     db: Session = Depends(get_session),
 ):
-    file = Files.get_file_by_id(id, db=db)
+    file = Files.get_file_by_id_and_user_id(id, user.id, db=db)
 
     if not file:
         raise HTTPException(
@@ -614,28 +582,18 @@ async def update_file_data_content_by_id(
             detail=ERROR_MESSAGES.NOT_FOUND,
         )
 
-    if (
-        file.user_id == user.id
-        or user.role == "admin"
-        or has_access_to_file(id, "write", user, db=db)
-    ):
-        try:
-            process_file(
-                request,
-                ProcessFileForm(file_id=id, content=form_data.content),
-                user=user,
-            )
-            file = Files.get_file_by_id(id=id, db=db)
-        except Exception as e:
-            log.exception(e)
-            log.error(f"Error processing file: {file.id}")
-
-        return {"content": file.data.get("content", "")}
-    else:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=ERROR_MESSAGES.NOT_FOUND,
+    try:
+        process_file(
+            request,
+            ProcessFileForm(file_id=id, content=form_data.content),
+            user=user,
         )
+        file = Files.get_file_by_id_and_user_id(id=id, user_id=user.id, db=db)
+    except Exception as e:
+        log.exception(e)
+        log.error(f"Error processing file: {file.id}")
+
+    return {"content": file.data.get("content", "")}
 
 
 ############################
@@ -650,7 +608,7 @@ async def get_file_content_by_id(
     attachment: bool = Query(False),
     db: Session = Depends(get_session),
 ):
-    file = Files.get_file_by_id(id, db=db)
+    file = Files.get_file_by_id_and_user_id(id, user.id, db=db)
 
     if not file:
         raise HTTPException(
@@ -658,64 +616,58 @@ async def get_file_content_by_id(
             detail=ERROR_MESSAGES.NOT_FOUND,
         )
 
-    if (
-        file.user_id == user.id
-        or user.role == "admin"
-        or has_access_to_file(id, "read", user, db=db)
-    ):
-        try:
-            filename = file.meta.get("name", file.filename)
-            encoded_filename = quote(filename)  # RFC5987 encoding
-            content_type = file.meta.get("content_type")
-            headers = {}
+    try:
+        filename = file.meta.get("name", file.filename)
+        encoded_filename = quote(filename)  # RFC5987 encoding
+        content_type = file.meta.get("content_type")
+        headers = {}
 
-            if attachment:
+        if attachment:
+            headers["Content-Disposition"] = (
+                f"attachment; filename*=UTF-8''{encoded_filename}"
+            )
+        else:
+            if content_type == "application/pdf" or filename.lower().endswith(".pdf"):
+                headers["Content-Disposition"] = (
+                    f"inline; filename*=UTF-8''{encoded_filename}"
+                )
+                content_type = "application/pdf"
+            elif content_type != "text/plain":
                 headers["Content-Disposition"] = (
                     f"attachment; filename*=UTF-8''{encoded_filename}"
                 )
-            else:
-                if content_type == "application/pdf" or filename.lower().endswith(
-                    ".pdf"
-                ):
-                    headers["Content-Disposition"] = (
-                        f"inline; filename*=UTF-8''{encoded_filename}"
-                    )
-                    content_type = "application/pdf"
-                elif content_type != "text/plain":
-                    headers["Content-Disposition"] = (
-                        f"attachment; filename*=UTF-8''{encoded_filename}"
-                    )
 
-            return DecryptedFileResponse(
-                file,
-                headers=headers,
-                media_type=content_type,
-            )
-        except FileNotFoundError:
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail=ERROR_MESSAGES.NOT_FOUND,
-            )
-        except RuntimeError as e:
-            if "No DEK cached" in str(e):
-                raise HTTPException(
-                    status_code=status.HTTP_401_UNAUTHORIZED,
-                    detail=ERROR_MESSAGES.DEFAULT(
-                        "User must re-login to access encrypted file"
-                    ),
-                )
-            raise
-        except Exception as e:
-            log.exception(e)
-            log.error("Error getting file content")
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=ERROR_MESSAGES.DEFAULT("Error getting file content"),
-            )
-    else:
+        return DecryptedFileResponse(
+            file,
+            user_id=user.id,
+            headers=headers,
+            media_type=content_type,
+        )
+    except FileNotFoundError:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=ERROR_MESSAGES.NOT_FOUND,
+        )
+    except EncryptedDataAccessDeniedError:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=ERROR_MESSAGES.NOT_FOUND,
+        )
+    except RuntimeError as e:
+        if "No DEK cached" in str(e):
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail=ERROR_MESSAGES.DEFAULT(
+                    "User must re-login to access encrypted file"
+                ),
+            )
+        raise
+    except Exception as e:
+        log.exception(e)
+        log.error("Error getting file content")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=ERROR_MESSAGES.DEFAULT("Error getting file content"),
         )
 
 
@@ -723,7 +675,7 @@ async def get_file_content_by_id(
 async def get_html_file_content_by_id(
     id: str, user=Depends(get_verified_user), db: Session = Depends(get_session)
 ):
-    file = Files.get_file_by_id(id, db=db)
+    file = Files.get_file_by_id_and_user_id(id, user.id, db=db)
 
     if not file:
         raise HTTPException(
@@ -738,38 +690,33 @@ async def get_html_file_content_by_id(
             detail=ERROR_MESSAGES.NOT_FOUND,
         )
 
-    if (
-        file.user_id == user.id
-        or user.role == "admin"
-        or has_access_to_file(id, "read", user, db=db)
-    ):
-        try:
-            return DecryptedFileResponse(file)
-        except FileNotFoundError:
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail=ERROR_MESSAGES.NOT_FOUND,
-            )
-        except RuntimeError as e:
-            if "No DEK cached" in str(e):
-                raise HTTPException(
-                    status_code=status.HTTP_401_UNAUTHORIZED,
-                    detail=ERROR_MESSAGES.DEFAULT(
-                        "User must re-login to access encrypted file"
-                    ),
-                )
-            raise
-        except Exception as e:
-            log.exception(e)
-            log.error("Error getting file content")
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=ERROR_MESSAGES.DEFAULT("Error getting file content"),
-            )
-    else:
+    try:
+        return DecryptedFileResponse(file, user_id=user.id)
+    except FileNotFoundError:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=ERROR_MESSAGES.NOT_FOUND,
+        )
+    except EncryptedDataAccessDeniedError:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=ERROR_MESSAGES.NOT_FOUND,
+        )
+    except RuntimeError as e:
+        if "No DEK cached" in str(e):
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail=ERROR_MESSAGES.DEFAULT(
+                    "User must re-login to access encrypted file"
+                ),
+            )
+        raise
+    except Exception as e:
+        log.exception(e)
+        log.error("Error getting file content")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=ERROR_MESSAGES.DEFAULT("Error getting file content"),
         )
 
 
@@ -777,7 +724,7 @@ async def get_html_file_content_by_id(
 async def get_file_content_by_id(
     id: str, user=Depends(get_verified_user), db: Session = Depends(get_session)
 ):
-    file = Files.get_file_by_id(id, db=db)
+    file = Files.get_file_by_id_and_user_id(id, user.id, db=db)
 
     if not file:
         raise HTTPException(
@@ -785,11 +732,7 @@ async def get_file_content_by_id(
             detail=ERROR_MESSAGES.NOT_FOUND,
         )
 
-    if (
-        file.user_id == user.id
-        or user.role == "admin"
-        or has_access_to_file(id, "read", user, db=db)
-    ):
+    if file.user_id == user.id:
         file_path = file.path
 
         # Handle Unicode filenames
@@ -801,8 +744,13 @@ async def get_file_content_by_id(
 
         if file_path:
             try:
-                return DecryptedFileResponse(file, headers=headers)
+                return DecryptedFileResponse(file, user_id=user.id, headers=headers)
             except FileNotFoundError:
+                raise HTTPException(
+                    status_code=status.HTTP_404_NOT_FOUND,
+                    detail=ERROR_MESSAGES.NOT_FOUND,
+                )
+            except EncryptedDataAccessDeniedError:
                 raise HTTPException(
                     status_code=status.HTTP_404_NOT_FOUND,
                     detail=ERROR_MESSAGES.NOT_FOUND,
@@ -846,7 +794,7 @@ async def get_file_content_by_id(
 async def delete_file_by_id(
     id: str, user=Depends(get_verified_user), db: Session = Depends(get_session)
 ):
-    file = Files.get_file_by_id(id, db=db)
+    file = Files.get_file_by_id_and_user_id(id, user.id, db=db)
 
     if not file:
         raise HTTPException(
@@ -854,32 +802,21 @@ async def delete_file_by_id(
             detail=ERROR_MESSAGES.NOT_FOUND,
         )
 
-    if (
-        file.user_id == user.id
-        or user.role == "admin"
-        or has_access_to_file(id, "write", user, db=db)
-    ):
-
-        result = Files.delete_file_by_id(id, db=db)
-        if result:
-            try:
-                Storage.delete_file(file.path)
-                VECTOR_DB_CLIENT.delete(collection_name=f"file-{id}")
-            except Exception as e:
-                log.exception(e)
-                log.error("Error deleting files")
-                raise HTTPException(
-                    status_code=status.HTTP_400_BAD_REQUEST,
-                    detail=ERROR_MESSAGES.DEFAULT("Error deleting files"),
-                )
-            return {"message": "File deleted successfully"}
-        else:
+    result = Files.delete_file_by_id(id, db=db)
+    if result:
+        try:
+            Storage.delete_file(file.path)
+            VECTOR_DB_CLIENT.delete(collection_name=f"file-{id}")
+        except Exception as e:
+            log.exception(e)
+            log.error("Error deleting files")
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
-                detail=ERROR_MESSAGES.DEFAULT("Error deleting file"),
+                detail=ERROR_MESSAGES.DEFAULT("Error deleting files"),
             )
+        return {"message": "File deleted successfully"}
     else:
         raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=ERROR_MESSAGES.NOT_FOUND,
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=ERROR_MESSAGES.DEFAULT("Error deleting file"),
         )

--- a/backend/open_webui/routers/images.py
+++ b/backend/open_webui/routers/images.py
@@ -12,17 +12,18 @@ from typing import Optional
 from urllib.parse import quote
 import requests
 from fastapi import APIRouter, Depends, HTTPException, Request, UploadFile
-from fastapi.responses import FileResponse
 
 from open_webui.config import CACHE_DIR
 from open_webui.constants import ERROR_MESSAGES
 from open_webui.env import ENABLE_FORWARD_USER_INFO_HEADERS
 
 from open_webui.models.chats import Chats
-from open_webui.routers.files import upload_file_handler, get_file_content_by_id
+from open_webui.models.files import Files
+from open_webui.routers.files import upload_file_handler
 from open_webui.utils.auth import get_admin_user, get_verified_user
 from open_webui.utils.access_control import has_permission
 from open_webui.utils.headers import include_user_info_headers
+from open_webui.utils.file_crypto import read_decrypted_file
 from open_webui.internal.db import get_session
 from sqlalchemy.orm import Session
 from open_webui.utils.images.comfyui import (
@@ -894,14 +895,14 @@ async def image_edits(
                 else:
                     file_id = data
 
-                file_response = await get_file_content_by_id(file_id, user)
-                if isinstance(file_response, FileResponse):
-                    file_path = file_response.path
-
-                    with open(file_path, "rb") as f:
-                        file_bytes = f.read()
-                        image_data = base64.b64encode(file_bytes).decode("utf-8")
-                        mime_type, _ = mimetypes.guess_type(file_path)
+                file = Files.get_file_by_id(file_id)
+                if file and (file.user_id == user.id or user.role == "admin"):
+                    image_data = base64.b64encode(read_decrypted_file(file)).decode(
+                        "utf-8"
+                    )
+                    mime_type = file.meta.get("content_type") if file.meta else None
+                    if not mime_type:
+                        mime_type, _ = mimetypes.guess_type(file.filename)
 
                     return f"data:{mime_type};base64,{image_data}"
             return data

--- a/backend/open_webui/routers/images.py
+++ b/backend/open_webui/routers/images.py
@@ -12,18 +12,17 @@ from typing import Optional
 from urllib.parse import quote
 import requests
 from fastapi import APIRouter, Depends, HTTPException, Request, UploadFile
+from fastapi.responses import FileResponse
 
 from open_webui.config import CACHE_DIR
 from open_webui.constants import ERROR_MESSAGES
 from open_webui.env import ENABLE_FORWARD_USER_INFO_HEADERS
 
 from open_webui.models.chats import Chats
-from open_webui.models.files import Files
-from open_webui.routers.files import upload_file_handler
+from open_webui.routers.files import upload_file_handler, get_file_content_by_id
 from open_webui.utils.auth import get_admin_user, get_verified_user
 from open_webui.utils.access_control import has_permission
 from open_webui.utils.headers import include_user_info_headers
-from open_webui.utils.file_crypto import read_decrypted_file
 from open_webui.internal.db import get_session
 from sqlalchemy.orm import Session
 from open_webui.utils.images.comfyui import (
@@ -895,14 +894,14 @@ async def image_edits(
                 else:
                     file_id = data
 
-                file = Files.get_file_by_id(file_id)
-                if file and (file.user_id == user.id or user.role == "admin"):
-                    image_data = base64.b64encode(read_decrypted_file(file)).decode(
-                        "utf-8"
-                    )
-                    mime_type = file.meta.get("content_type") if file.meta else None
-                    if not mime_type:
-                        mime_type, _ = mimetypes.guess_type(file.filename)
+                file_response = await get_file_content_by_id(file_id, user)
+                if isinstance(file_response, FileResponse):
+                    file_path = file_response.path
+
+                    with open(file_path, "rb") as f:
+                        file_bytes = f.read()
+                        image_data = base64.b64encode(file_bytes).decode("utf-8")
+                        mime_type, _ = mimetypes.guess_type(file_path)
 
                     return f"data:{mime_type};base64,{image_data}"
             return data

--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -38,8 +38,8 @@ from langchain_core.documents import Document
 
 from open_webui.models.files import FileModel, FileUpdateForm, Files
 from open_webui.models.knowledge import Knowledges
-from open_webui.storage.provider import Storage
 from open_webui.internal.db import get_session
+from open_webui.utils.file_crypto import decrypted_file_path
 from sqlalchemy.orm import Session
 
 
@@ -1663,7 +1663,6 @@ def process_file(
                 # Usage: /files/
                 file_path = file.path
                 if file_path:
-                    file_path = Storage.get_file(file_path)
                     loader = Loader(
                         engine=request.app.state.config.CONTENT_EXTRACTION_ENGINE,
                         user=user,
@@ -1696,9 +1695,10 @@ def process_file(
                         MINERU_API_TIMEOUT=request.app.state.config.MINERU_API_TIMEOUT,
                         MINERU_PARAMS=request.app.state.config.MINERU_PARAMS,
                     )
-                    docs = loader.load(
-                        file.filename, file.meta.get("content_type"), file_path
-                    )
+                    with decrypted_file_path(file) as file_path:
+                        docs = loader.load(
+                            file.filename, file.meta.get("content_type"), file_path
+                        )
 
                     docs = [
                         Document(

--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -36,6 +36,7 @@ from langchain_text_splitters import (
 )
 from langchain_core.documents import Document
 
+from open_webui.crypto_exceptions import EncryptedDataAccessDeniedError
 from open_webui.models.files import FileModel, FileUpdateForm, Files
 from open_webui.models.knowledge import Knowledges
 from open_webui.internal.db import get_session
@@ -1587,10 +1588,7 @@ def process_file(
     """
     Process a file and save its content to the vector database.
     """
-    if user.role == "admin":
-        file = Files.get_file_by_id(form_data.file_id, db=db)
-    else:
-        file = Files.get_file_by_id_and_user_id(form_data.file_id, user.id, db=db)
+    file = Files.get_file_by_id_and_user_id(form_data.file_id, user.id, db=db)
 
     if file:
         try:
@@ -1695,7 +1693,7 @@ def process_file(
                         MINERU_API_TIMEOUT=request.app.state.config.MINERU_API_TIMEOUT,
                         MINERU_PARAMS=request.app.state.config.MINERU_PARAMS,
                     )
-                    with decrypted_file_path(file) as file_path:
+                    with decrypted_file_path(file, user_id=user.id) as file_path:
                         docs = loader.load(
                             file.filename, file.meta.get("content_type"), file_path
                         )
@@ -1788,6 +1786,11 @@ def process_file(
                 except Exception as e:
                     raise e
 
+        except EncryptedDataAccessDeniedError:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=ERROR_MESSAGES.NOT_FOUND,
+            )
         except Exception as e:
             log.exception(e)
             Files.update_file_data_by_id(
@@ -2545,13 +2548,12 @@ def delete_entries_from_collection(
 ):
     try:
         if VECTOR_DB_CLIENT.has_collection(collection_name=form_data.collection_name):
-            file = Files.get_file_by_id(form_data.file_id, db=db)
-            if not file:
+            hash = Files.get_file_hash_by_id(form_data.file_id, db=db)
+            if hash is None:
                 raise HTTPException(
                     status_code=status.HTTP_404_NOT_FOUND,
                     detail=ERROR_MESSAGES.NOT_FOUND,
                 )
-            hash = file.hash
 
             VECTOR_DB_CLIENT.delete(
                 collection_name=form_data.collection_name,
@@ -2560,6 +2562,7 @@ def delete_entries_from_collection(
             return {"status": True}
         else:
             return {"status": False}
+
     except Exception as e:
         log.exception(e)
         return {"status": False}

--- a/backend/open_webui/test/util/test_crypto_context.py
+++ b/backend/open_webui/test/util/test_crypto_context.py
@@ -6,17 +6,23 @@ from open_webui.utils import crypto_context
 from open_webui.utils.crypto_context import (
     cache_dek,
     get_cached_dek,
+    get_current_user_id,
     purge_expired_sessions,
     remove_session,
     require_cached_dek,
+    require_current_user_dek,
+    set_current_user_id,
 )
+from open_webui.crypto_exceptions import EncryptedDataAccessDeniedError
 from open_webui.utils.crypto_utils import generate_dek
 
 
 @pytest.fixture(autouse=True)
 def _isolate_cache():
     crypto_context._dek_cache.clear()
+    set_current_user_id(None)
     yield
+    set_current_user_id(None)
     crypto_context._dek_cache.clear()
 
 
@@ -52,3 +58,27 @@ class TestRequireCachedDek:
         assert get_cached_dek("user-missing") is None
         with pytest.raises(RuntimeError):
             require_cached_dek("user-missing")
+
+
+class TestCurrentUserDek:
+    def test_requires_current_user_context(self):
+        with pytest.raises(RuntimeError, match="No current user context"):
+            require_current_user_dek("user-1")
+
+    def test_requires_owner_match(self):
+        set_current_user_id("admin")
+        try:
+            with pytest.raises(EncryptedDataAccessDeniedError):
+                require_current_user_dek("user-1")
+        finally:
+            set_current_user_id(None)
+
+    def test_returns_current_users_cached_dek(self):
+        dek = generate_dek()
+        cache_dek("user-1", dek, jti="jti-1", expires_at=time.time() + 60)
+        set_current_user_id("user-1")
+        try:
+            assert get_current_user_id() == "user-1"
+            assert require_current_user_dek("user-1") == dek
+        finally:
+            set_current_user_id(None)

--- a/backend/open_webui/test/util/test_file_crypto.py
+++ b/backend/open_webui/test/util/test_file_crypto.py
@@ -1,0 +1,89 @@
+import io
+import time
+
+import pytest
+
+from open_webui.utils import crypto_context
+from open_webui.utils.crypto_context import cache_dek
+from open_webui.utils.crypto_utils import FILE_MAGIC, generate_dek
+from open_webui.utils.file_crypto import (
+    decrypted_file_path,
+    read_decrypted_file,
+    store_encrypted_upload,
+)
+
+
+USER_ID = "test-user"
+FILE_ID = "file-1"
+
+
+class _File:
+    id = FILE_ID
+    user_id = USER_ID
+    filename = "report.txt"
+    meta = {"content_type": "text/plain"}
+
+    def __init__(self, path):
+        self.path = path
+
+
+@pytest.fixture(autouse=True)
+def _isolate_dek_cache():
+    crypto_context._dek_cache.clear()
+    yield
+    crypto_context._dek_cache.clear()
+
+
+@pytest.fixture
+def dek():
+    key = generate_dek()
+    cache_dek(USER_ID, key, jti="jti-1", expires_at=time.time() + 3600)
+    return key
+
+
+def test_store_encrypted_upload_writes_opaque_encrypted_file(tmp_path, monkeypatch, dek):
+    monkeypatch.setattr("open_webui.utils.file_crypto.STORAGE_PROVIDER", "local")
+    monkeypatch.setattr("open_webui.utils.file_crypto.UPLOAD_DIR", tmp_path)
+
+    size, path = store_encrypted_upload(
+        io.BytesIO(b"plain report"),
+        user_id=USER_ID,
+        file_id=FILE_ID,
+    )
+
+    assert size == len(b"plain report")
+    assert path == str(tmp_path / FILE_ID)
+    raw = (tmp_path / FILE_ID).read_bytes()
+    assert raw.startswith(FILE_MAGIC)
+    assert b"plain report" not in raw
+
+    assert read_decrypted_file(_File(path)) == b"plain report"
+
+
+def test_decrypted_file_path_creates_temporary_plaintext_file(tmp_path, monkeypatch, dek):
+    monkeypatch.setattr("open_webui.utils.file_crypto.STORAGE_PROVIDER", "local")
+    monkeypatch.setattr("open_webui.utils.file_crypto.UPLOAD_DIR", tmp_path)
+
+    _, path = store_encrypted_upload(
+        io.BytesIO(b"temporary plaintext"),
+        user_id=USER_ID,
+        file_id=FILE_ID,
+    )
+
+    with decrypted_file_path(_File(path)) as plaintext_path:
+        with open(plaintext_path, "rb") as f:
+            assert f.read() == b"temporary plaintext"
+
+
+def test_empty_upload_is_rejected_and_removed(tmp_path, monkeypatch, dek):
+    monkeypatch.setattr("open_webui.utils.file_crypto.STORAGE_PROVIDER", "local")
+    monkeypatch.setattr("open_webui.utils.file_crypto.UPLOAD_DIR", tmp_path)
+
+    with pytest.raises(ValueError):
+        store_encrypted_upload(
+            io.BytesIO(b""),
+            user_id=USER_ID,
+            file_id=FILE_ID,
+        )
+
+    assert not (tmp_path / FILE_ID).exists()

--- a/backend/open_webui/test/util/test_file_crypto.py
+++ b/backend/open_webui/test/util/test_file_crypto.py
@@ -4,7 +4,10 @@ import time
 import pytest
 
 from open_webui.utils import crypto_context
-from open_webui.utils.crypto_context import cache_dek
+from open_webui.utils.crypto_context import (
+    cache_dek,
+)
+from open_webui.crypto_exceptions import EncryptedDataAccessDeniedError
 from open_webui.utils.crypto_utils import FILE_MAGIC, generate_dek
 from open_webui.utils.file_crypto import (
     decrypted_file_path,
@@ -57,7 +60,7 @@ def test_store_encrypted_upload_writes_opaque_encrypted_file(tmp_path, monkeypat
     assert raw.startswith(FILE_MAGIC)
     assert b"plain report" not in raw
 
-    assert read_decrypted_file(_File(path)) == b"plain report"
+    assert read_decrypted_file(_File(path), user_id=USER_ID) == b"plain report"
 
 
 def test_decrypted_file_path_creates_temporary_plaintext_file(tmp_path, monkeypatch, dek):
@@ -70,9 +73,25 @@ def test_decrypted_file_path_creates_temporary_plaintext_file(tmp_path, monkeypa
         file_id=FILE_ID,
     )
 
-    with decrypted_file_path(_File(path)) as plaintext_path:
+    with decrypted_file_path(_File(path), user_id=USER_ID) as plaintext_path:
         with open(plaintext_path, "rb") as f:
             assert f.read() == b"temporary plaintext"
+
+
+def test_other_user_cannot_read_file_even_when_owner_dek_is_cached(
+    tmp_path, monkeypatch, dek
+):
+    monkeypatch.setattr("open_webui.utils.file_crypto.STORAGE_PROVIDER", "local")
+    monkeypatch.setattr("open_webui.utils.file_crypto.UPLOAD_DIR", tmp_path)
+
+    _, path = store_encrypted_upload(
+        io.BytesIO(b"owner only"),
+        user_id=USER_ID,
+        file_id=FILE_ID,
+    )
+
+    with pytest.raises(EncryptedDataAccessDeniedError):
+        read_decrypted_file(_File(path), user_id="admin-user")
 
 
 def test_empty_upload_is_rejected_and_removed(tmp_path, monkeypatch, dek):

--- a/backend/open_webui/test/util/test_file_hooks.py
+++ b/backend/open_webui/test/util/test_file_hooks.py
@@ -7,7 +7,11 @@ from sqlalchemy.orm import sessionmaker
 from open_webui.internal.db import Base
 from open_webui.models.files import File
 from open_webui.utils import crypto_context
-from open_webui.utils.crypto_context import cache_dek
+from open_webui.utils.crypto_context import (
+    cache_dek,
+    set_current_user_id,
+)
+from open_webui.crypto_exceptions import EncryptedDataAccessDeniedError
 from open_webui.utils.crypto_utils import (
     decrypt_json_value,
     decrypt_text,
@@ -27,7 +31,9 @@ USER_ID = "test-user"
 def dek() -> bytes:
     key = generate_dek()
     cache_dek(USER_ID, key, jti="test-jti", expires_at=time.time() + 3600)
+    set_current_user_id(USER_ID)
     yield key
+    set_current_user_id(None)
     crypto_context._dek_cache.clear()
 
 
@@ -182,9 +188,13 @@ class TestNoneHandling:
 class TestDekRequired:
     def test_insert_without_dek_raises(self, db):
         # No DEK cached for USER_ID
-        with pytest.raises(RuntimeError, match="No DEK cached"):
-            db.add(_make_file())
-            db.commit()
+        set_current_user_id(USER_ID)
+        try:
+            with pytest.raises(RuntimeError, match="No DEK cached"):
+                db.add(_make_file())
+                db.commit()
+        finally:
+            set_current_user_id(None)
 
     def test_load_without_dek_raises(self, db, dek):
         db.add(_make_file())
@@ -204,3 +214,22 @@ class TestDekRequired:
         f.filename = "renamed.pdf"
         with pytest.raises(RuntimeError, match="No DEK cached"):
             db.commit()
+
+    def test_load_as_different_user_raises_even_if_owner_dek_is_cached(self, db, dek):
+        db.add(_make_file())
+        db.commit()
+        db.expire_all()
+
+        other_dek = generate_dek()
+        cache_dek(
+            "admin-user",
+            other_dek,
+            jti="admin-jti",
+            expires_at=time.time() + 3600,
+        )
+        set_current_user_id("admin-user")
+        try:
+            with pytest.raises(EncryptedDataAccessDeniedError):
+                db.query(File).filter_by(id="f1").one()
+        finally:
+            set_current_user_id(USER_ID)

--- a/backend/open_webui/test/util/test_files_search.py
+++ b/backend/open_webui/test/util/test_files_search.py
@@ -8,7 +8,10 @@ from open_webui.internal import db as internal_db
 from open_webui.internal.db import Base
 from open_webui.models.files import File, Files
 from open_webui.utils import crypto_context
-from open_webui.utils.crypto_context import cache_dek
+from open_webui.utils.crypto_context import (
+    cache_dek,
+    set_current_user_id,
+)
 from open_webui.utils.crypto_utils import generate_dek
 
 # Ensure the encryption hooks are registered before File operations run.
@@ -26,7 +29,9 @@ def db(monkeypatch):
     SessionLocal = sessionmaker(bind=engine)
     session = SessionLocal()
     cache_dek(USER_ID, generate_dek(), jti="jti-1", expires_at=time.time() + 3600)
+    set_current_user_id(USER_ID)
     yield session
+    set_current_user_id(None)
     session.close()
     engine.dispose()
     crypto_context._dek_cache.clear()
@@ -91,19 +96,23 @@ class TestSearchFiles:
         _insert_files(db, ["mine.txt"])
         other_dek = generate_dek()
         cache_dek("other-user", other_dek, jti="j2", expires_at=time.time() + 3600)
-        db.add(
-            File(
-                id="other",
-                user_id="other-user",
-                filename="theirs.txt",
-                path="/uploads/other",
-                data={},
-                meta={"name": "theirs.txt"},
-                created_at=int(time.time()),
-                updated_at=int(time.time()),
+        set_current_user_id("other-user")
+        try:
+            db.add(
+                File(
+                    id="other",
+                    user_id="other-user",
+                    filename="theirs.txt",
+                    path="/uploads/other",
+                    data={},
+                    meta={"name": "theirs.txt"},
+                    created_at=int(time.time()),
+                    updated_at=int(time.time()),
+                )
             )
-        )
-        db.commit()
+            db.commit()
+        finally:
+            set_current_user_id(USER_ID)
 
         results = Files.search_files(user_id=USER_ID, db=db)
         assert {r.filename for r in results} == {"mine.txt"}

--- a/backend/open_webui/utils/auth.py
+++ b/backend/open_webui/utils/auth.py
@@ -23,6 +23,7 @@ from opentelemetry import trace
 
 
 from open_webui.utils.access_control import has_permission
+from open_webui.utils.crypto_context import set_current_user_id
 from open_webui.models.users import Users
 from open_webui.models.auths import Auths
 
@@ -336,6 +337,7 @@ async def get_current_user(
                     detail=ERROR_MESSAGES.INVALID_TOKEN,
                 )
             else:
+                set_current_user_id(user.id)
                 if WEBUI_AUTH_TRUSTED_EMAIL_HEADER:
                     trusted_email = request.headers.get(
                         WEBUI_AUTH_TRUSTED_EMAIL_HEADER, ""

--- a/backend/open_webui/utils/crypto_context.py
+++ b/backend/open_webui/utils/crypto_context.py
@@ -1,5 +1,8 @@
 import threading
+from contextvars import ContextVar
 from typing import Optional
+
+from open_webui.crypto_exceptions import EncryptedDataAccessDeniedError
 
 # ---------------------------------------------------------------------------
 # In-memory DEK cache with per-session (JTI) tracking.
@@ -40,6 +43,17 @@ class UserSessions:
 
 _cache_lock = threading.Lock()
 _dek_cache: dict[str, tuple[bytes, UserSessions]] = {}
+_current_user_id: ContextVar[Optional[str]] = ContextVar(
+    "crypto_current_user_id", default=None
+)
+
+
+def set_current_user_id(user_id: Optional[str]) -> None:
+    _current_user_id.set(user_id)
+
+
+def get_current_user_id() -> Optional[str]:
+    return _current_user_id.get()
 
 
 def cache_dek(user_id: str, dek: bytes, jti: str, expires_at: float) -> None:
@@ -68,6 +82,17 @@ def require_cached_dek(user_id: str) -> bytes:
     if dek is None:
         raise RuntimeError(f"No DEK cached for user {user_id}. User must re-login.")
     return dek
+
+
+def require_current_user_dek(owner_user_id: str) -> bytes:
+    current_user_id = get_current_user_id()
+    if current_user_id is None:
+        raise RuntimeError("No current user context. Cannot access encrypted data.")
+    if current_user_id != owner_user_id:
+        raise EncryptedDataAccessDeniedError(
+            "Cannot access another user's encrypted data."
+        )
+    return require_cached_dek(current_user_id)
 
 
 def remove_session(user_id: str, jti: str) -> None:

--- a/backend/open_webui/utils/file_crypto.py
+++ b/backend/open_webui/utils/file_crypto.py
@@ -1,0 +1,95 @@
+import tempfile
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator
+
+from fastapi.responses import StreamingResponse
+
+from open_webui.config import STORAGE_PROVIDER, UPLOAD_DIR
+from open_webui.constants import ERROR_MESSAGES
+from open_webui.storage.provider import Storage
+from open_webui.utils.crypto_context import require_cached_dek
+from open_webui.utils.crypto_utils import (
+    iter_decrypt_file,
+    stream_decrypt_file_to_path,
+    stream_encrypt_file,
+)
+
+
+def store_encrypted_upload(source, *, user_id: str, file_id: str) -> tuple[int, str]:
+    if STORAGE_PROVIDER != "local":
+        raise RuntimeError("Encrypted file upload currently supports local storage only")
+
+    dek = require_cached_dek(user_id)
+    destination_path = Path(UPLOAD_DIR) / file_id
+    size = stream_encrypt_file(
+        source,
+        destination_path,
+        dek,
+        user_id=user_id,
+        file_id=file_id,
+    )
+    if size == 0:
+        destination_path.unlink(missing_ok=True)
+        raise ValueError(ERROR_MESSAGES.EMPTY_CONTENT)
+
+    return size, str(destination_path)
+
+
+def get_encrypted_file_path(file) -> Path:
+    file_path = Path(Storage.get_file(file.path))
+    if not file_path.is_file():
+        raise FileNotFoundError(file_path)
+    return file_path
+
+
+def iter_decrypted_file(file) -> Iterator[bytes]:
+    dek = require_cached_dek(file.user_id)
+    yield from iter_decrypt_file(
+        get_encrypted_file_path(file),
+        dek,
+        user_id=file.user_id,
+        file_id=file.id,
+    )
+
+
+def read_decrypted_file(file) -> bytes:
+    return b"".join(iter_decrypted_file(file))
+
+
+def decrypt_file_to_path(file, destination_path: str | Path) -> int:
+    dek = require_cached_dek(file.user_id)
+    return stream_decrypt_file_to_path(
+        get_encrypted_file_path(file),
+        destination_path,
+        dek,
+        user_id=file.user_id,
+        file_id=file.id,
+    )
+
+
+@contextmanager
+def decrypted_file_path(file) -> Iterator[str]:
+    suffix = Path(file.filename or "").suffix
+    temp = tempfile.NamedTemporaryFile(delete=False, suffix=suffix)
+    temp_path = temp.name
+    temp.close()
+
+    try:
+        decrypt_file_to_path(file, temp_path)
+        yield temp_path
+    finally:
+        Path(temp_path).unlink(missing_ok=True)
+
+
+class DecryptedFileResponse(StreamingResponse):
+    def __init__(self, file, *, headers=None, media_type=None):
+        # Check the encrypted path before the response starts so missing files
+        # become normal HTTP errors in the route handler.
+        get_encrypted_file_path(file)
+        require_cached_dek(file.user_id)
+        super().__init__(
+            iter_decrypted_file(file),
+            headers=headers,
+            media_type=media_type,
+        )

--- a/backend/open_webui/utils/file_crypto.py
+++ b/backend/open_webui/utils/file_crypto.py
@@ -9,6 +9,7 @@ from open_webui.config import STORAGE_PROVIDER, UPLOAD_DIR
 from open_webui.constants import ERROR_MESSAGES
 from open_webui.storage.provider import Storage
 from open_webui.utils.crypto_context import require_cached_dek
+from open_webui.crypto_exceptions import EncryptedDataAccessDeniedError
 from open_webui.utils.crypto_utils import (
     iter_decrypt_file,
     stream_decrypt_file_to_path,
@@ -43,53 +44,61 @@ def get_encrypted_file_path(file) -> Path:
     return file_path
 
 
-def iter_decrypted_file(file) -> Iterator[bytes]:
-    dek = require_cached_dek(file.user_id)
+def require_file_owner(file, *, user_id: str) -> None:
+    if file.user_id != user_id:
+        raise EncryptedDataAccessDeniedError("Cannot decrypt another user's file.")
+
+
+def iter_decrypted_file(file, *, user_id: str) -> Iterator[bytes]:
+    require_file_owner(file, user_id=user_id)
+    dek = require_cached_dek(user_id)
     yield from iter_decrypt_file(
         get_encrypted_file_path(file),
         dek,
-        user_id=file.user_id,
+        user_id=user_id,
         file_id=file.id,
     )
 
 
-def read_decrypted_file(file) -> bytes:
-    return b"".join(iter_decrypted_file(file))
+def read_decrypted_file(file, *, user_id: str) -> bytes:
+    return b"".join(iter_decrypted_file(file, user_id=user_id))
 
 
-def decrypt_file_to_path(file, destination_path: str | Path) -> int:
-    dek = require_cached_dek(file.user_id)
+def decrypt_file_to_path(file, destination_path: str | Path, *, user_id: str) -> int:
+    require_file_owner(file, user_id=user_id)
+    dek = require_cached_dek(user_id)
     return stream_decrypt_file_to_path(
         get_encrypted_file_path(file),
         destination_path,
         dek,
-        user_id=file.user_id,
+        user_id=user_id,
         file_id=file.id,
     )
 
 
 @contextmanager
-def decrypted_file_path(file) -> Iterator[str]:
+def decrypted_file_path(file, *, user_id: str) -> Iterator[str]:
     suffix = Path(file.filename or "").suffix
     temp = tempfile.NamedTemporaryFile(delete=False, suffix=suffix)
     temp_path = temp.name
     temp.close()
 
     try:
-        decrypt_file_to_path(file, temp_path)
+        decrypt_file_to_path(file, temp_path, user_id=user_id)
         yield temp_path
     finally:
         Path(temp_path).unlink(missing_ok=True)
 
 
 class DecryptedFileResponse(StreamingResponse):
-    def __init__(self, file, *, headers=None, media_type=None):
+    def __init__(self, file, *, user_id: str, headers=None, media_type=None):
         # Check the encrypted path before the response starts so missing files
         # become normal HTTP errors in the route handler.
         get_encrypted_file_path(file)
-        require_cached_dek(file.user_id)
+        require_file_owner(file, user_id=user_id)
+        require_cached_dek(user_id)
         super().__init__(
-            iter_decrypted_file(file),
+            iter_decrypted_file(file, user_id=user_id),
             headers=headers,
             media_type=media_type,
         )

--- a/backend/open_webui/utils/file_hooks.py
+++ b/backend/open_webui/utils/file_hooks.py
@@ -8,7 +8,7 @@ using the file owner's DEK from the in-memory cache.
 from sqlalchemy import event
 
 from open_webui.models.files import File
-from open_webui.utils.crypto_context import require_cached_dek
+from open_webui.utils.crypto_context import require_current_user_dek
 from open_webui.utils.crypto_utils import (
     decrypt_json_value,
     decrypt_text,
@@ -18,7 +18,7 @@ from open_webui.utils.crypto_utils import (
 
 
 def _encrypt_fields(target: File) -> None:
-    dek = require_cached_dek(target.user_id)
+    dek = require_current_user_dek(target.user_id)
 
     target._filename_plaintext = target.filename
     target._data_plaintext = target.data
@@ -30,7 +30,7 @@ def _encrypt_fields(target: File) -> None:
 
 
 def _decrypt_fields(target: File) -> None:
-    dek = require_cached_dek(target.user_id)
+    dek = require_current_user_dek(target.user_id)
 
     target.filename = decrypt_text(target.filename, dek)
     target.data = decrypt_json_value(target.data, dek)

--- a/backend/open_webui/utils/files.py
+++ b/backend/open_webui/utils/files.py
@@ -11,13 +11,11 @@ from fastapi import (
     UploadFile,
 )
 from typing import Optional
-from pathlib import Path
-
-from open_webui.storage.provider import Storage
 
 from open_webui.models.chats import Chats
 from open_webui.models.files import Files
 from open_webui.routers.files import upload_file_handler
+from open_webui.utils.file_crypto import read_decrypted_file
 
 import mimetypes
 import base64
@@ -46,16 +44,11 @@ def get_image_base64_from_url(url: str) -> Optional[str]:
             if not file:
                 return None
 
-            file_path = Storage.get_file(file.path)
-            file_path = Path(file_path)
-
-            if file_path.is_file():
-                with open(file_path, "rb") as image_file:
-                    encoded_string = base64.b64encode(image_file.read()).decode("utf-8")
-                    content_type, _ = mimetypes.guess_type(file_path.name)
-                    return f"data:{content_type};base64,{encoded_string}"
-            else:
-                return None
+            encoded_string = base64.b64encode(read_decrypted_file(file)).decode("utf-8")
+            content_type = file.meta.get("content_type") if file.meta else None
+            if not content_type:
+                content_type, _ = mimetypes.guess_type(file.filename)
+            return f"data:{content_type};base64,{encoded_string}"
 
     except Exception as e:
         return None
@@ -160,18 +153,10 @@ def get_image_base64_from_file_id(id: str) -> Optional[str]:
         return None
 
     try:
-        file_path = Storage.get_file(file.path)
-        file_path = Path(file_path)
-
-        # Check if the file already exists in the cache
-        if file_path.is_file():
-            import base64
-
-            with open(file_path, "rb") as image_file:
-                encoded_string = base64.b64encode(image_file.read()).decode("utf-8")
-                content_type, _ = mimetypes.guess_type(file_path.name)
-                return f"data:{content_type};base64,{encoded_string}"
-        else:
-            return None
+        encoded_string = base64.b64encode(read_decrypted_file(file)).decode("utf-8")
+        content_type = file.meta.get("content_type") if file.meta else None
+        if not content_type:
+            content_type, _ = mimetypes.guess_type(file.filename)
+        return f"data:{content_type};base64,{encoded_string}"
     except Exception as e:
         return None

--- a/backend/open_webui/utils/files.py
+++ b/backend/open_webui/utils/files.py
@@ -28,7 +28,7 @@ BASE64_IMAGE_URL_PREFIX = re.compile(r"data:image/\w+;base64,", re.IGNORECASE)
 MARKDOWN_IMAGE_URL_PATTERN = re.compile(r"!\[(.*?)\]\((.+?)\)", re.IGNORECASE)
 
 
-def get_image_base64_from_url(url: str) -> Optional[str]:
+def get_image_base64_from_url(url: str, user_id: Optional[str] = None) -> Optional[str]:
     try:
         if url.startswith("http"):
             # Download the image from the URL
@@ -39,12 +39,17 @@ def get_image_base64_from_url(url: str) -> Optional[str]:
             content_type = response.headers.get("Content-Type", "image/png")
             return f"data:{content_type};base64,{encoded_string}"
         else:
-            file = Files.get_file_by_id(url)
+            if user_id is None:
+                return None
+
+            file = Files.get_file_by_id_and_user_id(url, user_id)
 
             if not file:
                 return None
 
-            encoded_string = base64.b64encode(read_decrypted_file(file)).decode("utf-8")
+            encoded_string = base64.b64encode(
+                read_decrypted_file(file, user_id=user_id)
+            ).decode("utf-8")
             content_type = file.meta.get("content_type") if file.meta else None
             if not content_type:
                 content_type, _ = mimetypes.guess_type(file.filename)
@@ -147,13 +152,20 @@ def get_file_url_from_base64(request, base64_file_string, metadata, user):
     return None
 
 
-def get_image_base64_from_file_id(id: str) -> Optional[str]:
-    file = Files.get_file_by_id(id)
+def get_image_base64_from_file_id(
+    id: str, user_id: Optional[str] = None
+) -> Optional[str]:
+    if user_id is None:
+        return None
+
+    file = Files.get_file_by_id_and_user_id(id, user_id)
     if not file:
         return None
 
     try:
-        encoded_string = base64.b64encode(read_decrypted_file(file)).decode("utf-8")
+        encoded_string = base64.b64encode(
+            read_decrypted_file(file, user_id=user_id)
+        ).decode("utf-8")
         content_type = file.meta.get("content_type") if file.meta else None
         if not content_type:
             content_type, _ = mimetypes.guess_type(file.filename)

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -1360,7 +1360,7 @@ def apply_params_to_form_data(form_data, model):
     return form_data
 
 
-async def convert_url_images_to_base64(form_data):
+async def convert_url_images_to_base64(form_data, user):
     messages = form_data.get("messages", [])
 
     for message in messages:
@@ -1382,7 +1382,7 @@ async def convert_url_images_to_base64(form_data):
 
             try:
                 base64_data = await asyncio.to_thread(
-                    get_image_base64_from_url, image_url
+                    get_image_base64_from_url, image_url, user.id
                 )
                 new_content.append(
                     {
@@ -1416,7 +1416,7 @@ async def process_chat_payload(request, form_data, user, metadata, model):
         except:
             pass
 
-    form_data = await convert_url_images_to_base64(form_data)
+    form_data = await convert_url_images_to_base64(form_data, user)
 
     event_emitter = get_event_emitter(metadata)
     event_caller = get_event_call(metadata)


### PR DESCRIPTION
> **Stacked on top of #33.** Base branch is `za/crypto-stream-file`. 依存順は #32 -> #34 -> #33 -> この PR です。

## Summary

ファイル本体の保存/読取経路を、#33 の chunked AES-GCM プリミティブに接続します。

また、暗号化ファイルの読み出しは、admin権限や共有アクセスではなく、ファイル所有者本人のDEK境界に寄せます。

## Changes

- `utils/file_crypto.py`
  - `store_encrypted_upload()` で upload stream を chunked AES-GCM 暗号化して保存
  - `iter_decrypted_file()` / `read_decrypted_file()` で保存済み暗号化ファイルを復号
  - `decrypted_file_path()` で RAG/STT 向けに一時平文ファイルを作成し、利用後に削除
  - `DecryptedFileResponse` でダウンロード時に復号 byte stream を返す
  - 復号直前に `user_id` と `file.user_id` を照合し、他ユーザーのファイル復号を拒否
- `routers/files.py`
  - アップロード時に `Storage.upload_file()` ではなく `store_encrypted_upload()` を使用
  - 保存先ファイル名を `file_id` のみにして元ファイル名を含めない
  - `/content`, `/content/{file_name}`, `/content/html` で復号ストリームを返す
  - DEK 未キャッシュ時は 401 を返す
  - 所有者境界違反は詳細を出さず 404 を返す
  - admin でも本人のファイルだけ取得・検索・削除するように変更
  - アップロード途中失敗時は保存済み暗号化ファイルを削除
- `routers/retrieval.py`
  - RAG 処理時、loader へ暗号化ファイル path を直接渡さず、一時復号 path を渡す
  - vector DB 削除処理では `File` 全体ではなく `hash` のみ取得し、不要な復号を避ける
- `routers/files.py` の STT 経路
  - 音声文字起こし時も一時復号 path を渡す
- `utils/files.py` / `utils/middleware.py`
  - 通常チャットのVision向け画像base64化で、OpenWebUI内のfile_id画像を本人DEKで復号してからbase64化
  - 外部URL画像は従来どおりHTTP取得
- `utils/crypto_context.py` / `utils/auth.py` / `utils/file_hooks.py`
  - JWT認証済みリクエストの現在ユーザーIDをContextVarで保持
  - fileテーブルの透過的復号時も、現在ユーザーとファイル所有者が一致する場合のみDEKを使う
- `test/util/test_file_crypto.py`
  - 暗号化保存、復号読取、一時復号 path、他ユーザー復号拒否、空ファイル拒否と削除を追加テスト
- `test/util/test_crypto_context.py` / `test_file_hooks.py` / `test_files_search.py`
  - 現在ユーザーDEK境界、ORM hookでの所有者不一致拒否、検索時の本人スコープを確認

## How to test

```sh
cd backend
WEBUI_SECRET_KEY=test python -m pytest \
  open_webui/test/util/test_crypto_utils_stream.py \
  open_webui/test/util/test_crypto_context.py \
  open_webui/test/util/test_file_crypto.py \
  open_webui/test/util/test_file_hooks.py \
  open_webui/test/util/test_files_search.py \
  -q
```

確認済み（Docker / Python 3.11）:

```text
59 passed, 2 warnings
```

## Notes

- この PR はローカルストレージ保存を対象にしています。`STORAGE_PROVIDER != local` では暗号化 upload を拒否します。
- Knowledge 側の filename 参照/検索対応は予定どおり後続 PR #36 で扱います。
- owner の DEK がメモリにない場合、復号できないため再ログインが必要です。
