### PR TITLE
Knowledge file search for encrypted filenames

### DIFF
--- a/backend/open_webui/models/knowledge.py
+++ b/backend/open_webui/models/knowledge.py
@@ -293,24 +293,28 @@ class KnowledgeTable:
                 # This makes the database handle filtering, even with 10k+ KBs
                 query = has_permission(db, Knowledge, query, filter)
 
-                # Apply filename search
-                if filter:
-                    q = filter.get("query")
-                    if q:
-                        query = query.filter(File.filename.ilike(f"%{q}%"))
-
                 # Order by file changes
                 query = query.order_by(File.updated_at.desc())
 
+                rows = query.all()
+                if filter:
+                    q = filter.get("query")
+                    if q:
+                        query_key = q.lower()
+                        filtered_rows = []
+                        for file, user, knowledge in rows:
+                            filename = (file.filename or "").lower()
+                            if query_key in filename:
+                                filtered_rows.append((file, user, knowledge))
+                        rows = filtered_rows
+
                 # Count before pagination
-                total = query.count()
+                total = len(rows)
 
                 if skip:
-                    query = query.offset(skip)
+                    rows = rows[skip:]
                 if limit:
-                    query = query.limit(limit)
-
-                rows = query.all()
+                    rows = rows[:limit]
 
                 items = []
                 for file, user, knowledge in rows:
@@ -427,11 +431,12 @@ class KnowledgeTable:
                     .filter(KnowledgeFile.knowledge_id == knowledge_id)
                 )
 
+                query_key = None
+                order_by = None
+                direction = None
+
                 if filter:
                     query_key = filter.get("query")
-                    if query_key:
-                        query = query.filter(or_(File.filename.ilike(f"%{query_key}%")))
-
                     view_option = filter.get("view_option")
                     if view_option == "created":
                         query = query.filter(KnowledgeFile.user_id == user_id)
@@ -441,12 +446,7 @@ class KnowledgeTable:
                     order_by = filter.get("order_by")
                     direction = filter.get("direction")
 
-                    if order_by == "name":
-                        if direction == "asc":
-                            query = query.order_by(File.filename.asc())
-                        else:
-                            query = query.order_by(File.filename.desc())
-                    elif order_by == "created_at":
+                    if order_by == "created_at":
                         if direction == "asc":
                             query = query.order_by(File.created_at.asc())
                         else:
@@ -462,15 +462,28 @@ class KnowledgeTable:
                 else:
                     query = query.order_by(File.updated_at.desc())
 
-                # Count BEFORE pagination
-                total = query.count()
-
-                if skip:
-                    query = query.offset(skip)
-                if limit:
-                    query = query.limit(limit)
-
                 items = query.all()
+                if query_key:
+                    normalized_query = query_key.lower()
+                    filtered_items = []
+                    for file, user in items:
+                        filename = (file.filename or "").lower()
+                        if normalized_query in filename:
+                            filtered_items.append((file, user))
+                    items = filtered_items
+
+                if order_by == "name":
+                    items = sorted(
+                        items,
+                        key=lambda item: (item[0].filename or "").lower(),
+                        reverse=direction != "asc",
+                    )
+
+                total = len(items)
+                if skip:
+                    items = items[skip:]
+                if limit:
+                    items = items[:limit]
 
                 files = []
                 for file, user in items:

--- a/backend/open_webui/test/util/test_knowledge_files_search.py
+++ b/backend/open_webui/test/util/test_knowledge_files_search.py
@@ -1,0 +1,211 @@
+import time
+
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker
+
+from open_webui.internal import db as internal_db
+from open_webui.internal.db import Base
+from open_webui.models.files import File
+from open_webui.models.knowledge import Knowledge, KnowledgeFile, Knowledges
+from open_webui.models.users import User
+from open_webui.utils import crypto_context
+from open_webui.utils.crypto_context import cache_dek
+from open_webui.utils.crypto_utils import generate_dek
+
+# Ensure File ORM load/save operations transparently encrypt/decrypt columns.
+import open_webui.utils.file_hooks  # noqa: F401
+
+
+USER_ID = "knowledge-user"
+KNOWLEDGE_ID = "knowledge-1"
+
+
+@pytest.fixture
+def db(monkeypatch):
+    monkeypatch.setattr(internal_db, "DATABASE_ENABLE_SESSION_SHARING", True)
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(
+        engine,
+        tables=[
+            User.__table__,
+            File.__table__,
+            Knowledge.__table__,
+            KnowledgeFile.__table__,
+        ],
+    )
+    SessionLocal = sessionmaker(bind=engine)
+    session = SessionLocal()
+    cache_dek(USER_ID, generate_dek(), jti="jti-1", expires_at=time.time() + 3600)
+    _insert_user(session)
+    _insert_knowledge(session)
+    yield session
+    session.close()
+    engine.dispose()
+    crypto_context._dek_cache.clear()
+
+
+def _insert_user(db):
+    now = int(time.time())
+    db.add(
+        User(
+            id=USER_ID,
+            email="knowledge-user@example.com",
+            role="user",
+            name="Knowledge User",
+            profile_image_url="/user.png",
+            last_active_at=now,
+            created_at=now,
+            updated_at=now,
+        )
+    )
+    db.commit()
+
+
+def _insert_knowledge(db):
+    now = int(time.time())
+    db.add(
+        Knowledge(
+            id=KNOWLEDGE_ID,
+            user_id=USER_ID,
+            name="Knowledge",
+            description="Knowledge description",
+            meta=None,
+            access_control=None,
+            created_at=now,
+            updated_at=now,
+        )
+    )
+    db.commit()
+
+
+def _insert_files(db, names):
+    now = int(time.time())
+    for i, name in enumerate(names):
+        file_id = f"file-{i}"
+        db.add(
+            File(
+                id=file_id,
+                user_id=USER_ID,
+                filename=name,
+                path=f"/uploads/{file_id}",
+                data={"status": "completed", "content": f"content for {name}"},
+                meta={"name": name, "content_type": "text/plain"},
+                created_at=now + i,
+                updated_at=now + i,
+            )
+        )
+        db.add(
+            KnowledgeFile(
+                id=f"kf-{i}",
+                knowledge_id=KNOWLEDGE_ID,
+                file_id=file_id,
+                user_id=USER_ID,
+                created_at=now + i,
+                updated_at=now + i,
+            )
+        )
+    db.commit()
+    db.expire_all()
+
+
+def _raw_filename(db, file_id):
+    return db.execute(
+        text("SELECT filename FROM file WHERE id = :id"),
+        {"id": file_id},
+    ).scalar_one()
+
+
+class TestSearchKnowledgeFiles:
+    def test_search_uses_decrypted_filename(self, db):
+        _insert_files(db, ["report-alpha.txt", "memo-beta.txt"])
+        assert "report-alpha" not in _raw_filename(db, "file-0")
+
+        result = Knowledges.search_knowledge_files(
+            filter={"user_id": USER_ID, "query": "alpha"},
+            db=db,
+        )
+
+        assert result.total == 1
+        assert [item.filename for item in result.items] == ["report-alpha.txt"]
+
+    def test_search_paginates_after_filename_filter(self, db):
+        _insert_files(
+            db,
+            ["alpha-1.txt", "beta.txt", "alpha-2.txt", "alpha-3.txt"],
+        )
+
+        result = Knowledges.search_knowledge_files(
+            filter={"user_id": USER_ID, "query": "alpha"},
+            skip=1,
+            limit=1,
+            db=db,
+        )
+
+        assert result.total == 3
+        assert len(result.items) == 1
+
+
+class TestSearchFilesById:
+    def test_search_uses_decrypted_filename(self, db):
+        _insert_files(db, ["report-alpha.txt", "memo-beta.txt"])
+
+        result = Knowledges.search_files_by_id(
+            KNOWLEDGE_ID,
+            USER_ID,
+            filter={"query": "beta"},
+            db=db,
+        )
+
+        assert result.total == 1
+        assert [item.filename for item in result.items] == ["memo-beta.txt"]
+
+    def test_name_sort_uses_decrypted_filename_ascending(self, db):
+        _insert_files(db, ["charlie.txt", "alpha.txt", "bravo.txt"])
+
+        result = Knowledges.search_files_by_id(
+            KNOWLEDGE_ID,
+            USER_ID,
+            filter={"order_by": "name", "direction": "asc"},
+            db=db,
+        )
+
+        assert [item.filename for item in result.items] == [
+            "alpha.txt",
+            "bravo.txt",
+            "charlie.txt",
+        ]
+
+    def test_name_sort_uses_decrypted_filename_descending(self, db):
+        _insert_files(db, ["charlie.txt", "alpha.txt", "bravo.txt"])
+
+        result = Knowledges.search_files_by_id(
+            KNOWLEDGE_ID,
+            USER_ID,
+            filter={"order_by": "name", "direction": "desc"},
+            db=db,
+        )
+
+        assert [item.filename for item in result.items] == [
+            "charlie.txt",
+            "bravo.txt",
+            "alpha.txt",
+        ]
+
+    def test_search_paginates_after_filename_filter(self, db):
+        _insert_files(
+            db,
+            ["alpha-1.txt", "beta.txt", "alpha-2.txt", "alpha-3.txt"],
+        )
+
+        result = Knowledges.search_files_by_id(
+            KNOWLEDGE_ID,
+            USER_ID,
+            filter={"query": "alpha"},
+            skip=1,
+            limit=1,
+            db=db,
+        )
+
+        assert result.total == 3
+        assert len(result.items) == 1


### PR DESCRIPTION
## summary
Knowledge に紐づくファイル検索/名前順ソートが、暗号化済みの file.filename でも動作するようにします。

## changes
- Knowledge横断のファイル検索で、DB上の暗号文 filename に対する LIKE 検索をやめ、ORMロード後に復号済み filename で検索するように変更
- 特定Knowledge内のファイル一覧で、filename検索と name ソートを復号後の filename に対する Python 側処理へ変更
- access control、Knowledge ID filter、created_at/updated_at ソートなど、暗号化対象ではない条件はDB側処理のまま維持
- filename検索後の件数を total とし、検索/ソート後に pagination するように変更
- 暗号化済み filename に対する Knowledge ファイル検索/名前順ソートのテストを追加

## notes
- file.filename はDB上では暗号文のため、DBの LIKE 検索や filename順ソートでは平文ファイル名として扱えません。
- そのため、検索対象候補をORMでロードして file hook により復号した後、Python側で filename 検索/名前順ソートを行います。
- この変更により、filename検索時はDB側で filename 条件や pagination を完結できません。大量件数ではロード量が増えるトレードオフがありますが、暗号化後の正しい検索挙動を優先しています。

## how to test
Docker内で以下を実行しました。

```bash
cd /app/backend && python -m pytest open_webui/test/util/test_knowledge_files_search.py -v
```

結果:

```text
6 passed, 2 warnings
```

関連テストも実行しました。

```bash
cd /app/backend && python -m pytest open_webui/test/util/test_file_hooks.py open_webui/test/util/test_files_search.py open_webui/test/util/test_knowledge_files_search.py -v
```

結果:

```text
25 passed, 2 warnings
```

warnings は既存の SQLAlchemy/Alembic deprecation 警告です。

UIでは以下を確認済みです。

- Knowledge詳細画面の「コレクションの検索」で、Knowledge内ファイルをファイル名検索できること
- チャット入力欄で `#台風` のように入力し、Knowledge横断のファイル検索結果に該当ファイルが表示されること