### PR TITLE
test(auths): cover DEK generation and wrapping at user creation (#43)

### DIFF
--- a/backend/open_webui/test/util/test_auths_user_creation.py
+++ b/backend/open_webui/test/util/test_auths_user_creation.py
@@ -1,0 +1,137 @@
+from dataclasses import dataclass
+
+import pytest
+from cryptography.exceptions import InvalidTag
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker
+
+from open_webui.internal import db as internal_db
+from open_webui.internal.db import Base
+from open_webui.models.auths import Auth, Auths, UserWithDek
+from open_webui.models.users import User
+from open_webui.utils.crypto_utils import NONCE_SIZE, derive_kek, unwrap_dek
+
+USER_A = {
+    "email": "alice@example.com",
+    "name": "Alice",
+    "hashed_password": "hashed::alice",
+    "raw_password": "alice-correct-horse",
+}
+USER_B = {
+    "email": "bob@example.com",
+    "name": "Bob",
+    "hashed_password": "hashed::bob",
+    "raw_password": "bob-battery-staple",
+}
+
+
+@dataclass
+class Created:
+    session: object
+    a: UserWithDek
+    b: UserWithDek
+
+
+@pytest.fixture(scope="module")
+def created() -> Created:
+    """Create two accounts once (2 Argon2id derivations) and reuse them."""
+    mp = pytest.MonkeyPatch()
+    mp.setattr(internal_db, "DATABASE_ENABLE_SESSION_SHARING", True)
+
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine, tables=[User.__table__, Auth.__table__])
+    session = sessionmaker(bind=engine)()
+
+    a = Auths.insert_new_auth(
+        email=USER_A["email"],
+        hashed_password=USER_A["hashed_password"],
+        name=USER_A["name"],
+        raw_password=USER_A["raw_password"],
+        role="user",
+        db=session,
+    )
+    b = Auths.insert_new_auth(
+        email=USER_B["email"],
+        hashed_password=USER_B["hashed_password"],
+        name=USER_B["name"],
+        raw_password=USER_B["raw_password"],
+        role="user",
+        db=session,
+    )
+
+    yield Created(session=session, a=a, b=b)
+
+    session.close()
+    engine.dispose()
+    mp.undo()
+
+
+def _raw_auth_row(session, user_id):
+    """Read the stored auth columns directly from SQL (bypassing the ORM)."""
+    return session.execute(
+        text(
+            "SELECT kdf_salt, wrapped_dek, password FROM auth WHERE id = :id"
+        ),
+        {"id": user_id},
+    ).one()
+
+
+class TestReturnValue:
+    def test_returns_user_with_dek(self, created):
+        assert isinstance(created.a, UserWithDek)
+        assert created.a.user.email == USER_A["email"]
+
+    def test_returned_dek_is_256_bits(self, created):
+        assert isinstance(created.a.dek, bytes)
+        assert len(created.a.dek) == 32
+
+
+class TestPersistence:
+    def test_kdf_salt_persisted_as_16_bytes(self, created):
+        kdf_salt, _, _ = _raw_auth_row(created.session, created.a.user.id)
+        assert isinstance(kdf_salt, bytes)
+        assert len(kdf_salt) == 16
+
+    def test_wrapped_dek_persisted_with_expected_length(self, created):
+        _, wrapped_dek, _ = _raw_auth_row(created.session, created.a.user.id)
+        # nonce(12) + ciphertext(32, == DEK size) + GCM tag(16)
+        assert len(wrapped_dek) == NONCE_SIZE + 32 + 16
+
+
+class TestNoPlaintextLeak:
+    def test_dek_is_stored_wrapped_not_plaintext(self, created):
+        _, wrapped_dek, _ = _raw_auth_row(created.session, created.a.user.id)
+        assert wrapped_dek != created.a.dek
+
+    def test_password_column_is_hashed_not_raw(self, created):
+        _, _, password = _raw_auth_row(created.session, created.a.user.id)
+        assert password == USER_A["hashed_password"]
+        assert USER_A["raw_password"] not in password
+
+
+class TestWrappedDekRoundtrip:
+    def test_wrapped_dek_unwraps_to_returned_dek(self, created):
+        kdf_salt, wrapped_dek, _ = _raw_auth_row(
+            created.session, created.a.user.id
+        )
+        kek = derive_kek(USER_A["raw_password"], kdf_salt)
+        assert unwrap_dek(wrapped_dek, kek) == created.a.dek
+
+    def test_wrong_password_cannot_unwrap(self, created):
+        kdf_salt, wrapped_dek, _ = _raw_auth_row(
+            created.session, created.a.user.id
+        )
+        wrong_kek = derive_kek("not-the-password", kdf_salt)
+        with pytest.raises(InvalidTag):
+            unwrap_dek(wrapped_dek, wrong_kek)
+
+
+class TestKeySeparation:
+    def test_two_users_get_distinct_dek(self, created):
+        assert created.a.dek != created.b.dek
+
+    def test_two_users_get_distinct_salt_and_wrapped_dek(self, created):
+        salt_a, wrapped_a, _ = _raw_auth_row(created.session, created.a.user.id)
+        salt_b, wrapped_b, _ = _raw_auth_row(created.session, created.b.user.id)
+        assert salt_a != salt_b
+        assert wrapped_a != wrapped_b


### PR DESCRIPTION
## Summary

親Issue #40 / 子Issue #43。`AuthsTable.insert_new_auth`（`backend/open_webui/models/auths.py`）について、**ユーザー作成時にDEKが生成され、KEKでラップされて暗号化状態でDBに保存される**ことを検証する単体テストを追加する。

このメソッドはアカウント作成フローの心臓部であり、ここで保存される `kdf_salt` / `wrapped_dek` がログイン時のDEK復元（`authenticate_user`）の前提になる。回帰すると「全データ復号不能」または「平文鍵漏洩」に直結する。


## Changes

- `backend/open_webui/test/util/test_auths_user_creation.py` を新規追加（10ケース）
  - **戻り値**: `insert_new_auth` が `UserWithDek` を返し、`dek` が32バイトであること
  - **永続化**: `auth` 行に `kdf_salt`(16B) と `wrapped_dek`(nonce12+暗号文32+tag16=60B) が保存されること
  - **平文非保存**: DEKはラップ（暗号化）された形でのみ保存され、保存された `wrapped_dek` が平文DEKと一致しないこと
  - **パスワード**: `password` 列はハッシュ済みで、生パスワードが残らないこと
  - **往復**: 保存された `wrapped_dek` を `derive_kek(raw_password, kdf_salt)` のKEKでアンラップすると返却DEKと一致すること
  - **誤パスワード**: 誤パスワード由来のKEKではアンラップ不可（`InvalidTag`）であること
  - **鍵分離**: 2ユーザー間で dek / kdf_salt / wrapped_dek がそれぞれ異なること
- 既存のモデル層テスト（`test_chat_search.py`）に倣い、インメモリSQLite（`Auth` / `User`）を使用
- Argon2id（2 GiB）は `insert_new_auth` ごとに1回走るため、2アカウント作成を module スコープのフィクスチャで1回だけ行い再利用

## How to test
Docker（本リポジトリ由来イメージを 3.11 実行環境として利用、作業ツリーをマウント）:

```
docker run --rm --entrypoint python `
  -e WEBUI_SECRET_KEY=test-secret-key -e ENABLE_DB_MIGRATIONS=false `
  -e "DATABASE_URL=sqlite:////tmp/owui-test.db" -e DATA_DIR=/tmp `
  -v "<repo>/backend:/app/backend" -w /app/backend `
  <python311-image> -m pytest open_webui/test/util/test_auths_user_creation.py -v
```

- 10ケース全てpass（Python 3.11.14 / Linux、約8秒）
- 回帰確認: `test_chat_search.py` + `test_crypto_context.py` → 18 passed

Closes #43
