### PR TITLE
test(auths): cover DEK decryption at login (#45)

### DIFF
--- a/backend/open_webui/test/util/test_auths_login.py
+++ b/backend/open_webui/test/util/test_auths_login.py
@@ -1,0 +1,163 @@
+from dataclasses import dataclass
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from open_webui.internal import db as internal_db
+from open_webui.internal.db import Base
+from open_webui.models.auths import Auth, Auths, UserWithDek
+from open_webui.models.users import User
+
+NOW = 1_700_000_000
+
+ACTIVE = {
+    "email": "alice@example.com",
+    "name": "Alice",
+    "hashed_password": "hashed::alice",
+    "raw_password": "alice-correct-horse",
+}
+INACTIVE = {
+    "id": "inactive-user",
+    "name": "Ghost",
+    "email": "ghost@example.com",
+    "hashed_password": "hashed::ghost",
+}
+
+
+def _always_true(_stored_hash):
+    return True
+
+
+def _always_false(_stored_hash):
+    return False
+
+
+@dataclass
+class Accounts:
+    session: object
+    created: UserWithDek
+
+
+@pytest.fixture(scope="module")
+def accounts() -> Accounts:
+    mp = pytest.MonkeyPatch()
+    mp.setattr(internal_db, "DATABASE_ENABLE_SESSION_SHARING", True)
+
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine, tables=[User.__table__, Auth.__table__])
+    session = sessionmaker(bind=engine)()
+
+    created = Auths.insert_new_auth(
+        email=ACTIVE["email"],
+        hashed_password=ACTIVE["hashed_password"],
+        name=ACTIVE["name"],
+        raw_password=ACTIVE["raw_password"],
+        role="user",
+        db=session,
+    )
+
+    # Inactive account
+    session.add(
+        User(
+            id=INACTIVE["id"],
+            email=INACTIVE["email"],
+            role="user",
+            name=INACTIVE["name"],
+            profile_image_url="/user.png",
+            last_active_at=NOW,
+            created_at=NOW,
+            updated_at=NOW,
+        )
+    )
+    session.add(
+        Auth(
+            id=INACTIVE["id"],
+            email=INACTIVE["email"],
+            password=INACTIVE["hashed_password"],
+            active=False,
+            kdf_salt=b"\x00" * 16,
+            wrapped_dek=b"\x00" * 60,
+        )
+    )
+    session.commit()
+
+    yield Accounts(session=session, created=created)
+
+    session.close()
+    engine.dispose()
+    mp.undo()
+
+
+@pytest.fixture(scope="module")
+def login_ok(accounts) -> UserWithDek:
+    return Auths.authenticate_user(
+        ACTIVE["email"],
+        ACTIVE["raw_password"],
+        verify_password=_always_true,
+        db=accounts.session,
+    )
+
+
+class TestSuccessfulLogin:
+    def test_returns_user_with_dek(self, login_ok):
+        assert isinstance(login_ok, UserWithDek)
+        assert login_ok.user.email == ACTIVE["email"]
+
+    def test_recovers_the_signup_dek(self, login_ok, accounts):
+        assert login_ok.dek == accounts.created.dek
+
+
+class TestVerifyPasswordContract:
+    def test_verify_password_receives_stored_hash(self, accounts):
+        captured = {}
+
+        def verify(stored_hash):
+            captured["arg"] = stored_hash
+            return False
+
+        Auths.authenticate_user(
+            ACTIVE["email"],
+            ACTIVE["raw_password"],
+            verify_password=verify,
+            db=accounts.session,
+        )
+        assert captured["arg"] == ACTIVE["hashed_password"]
+
+
+class TestFailedLogin:
+    def test_wrong_password_hash_returns_none(self, accounts):
+        result = Auths.authenticate_user(
+            ACTIVE["email"],
+            ACTIVE["raw_password"],
+            verify_password=_always_false,
+            db=accounts.session,
+        )
+        assert result is None
+
+    def test_unknown_email_returns_none(self, accounts):
+        result = Auths.authenticate_user(
+            "nobody@example.com",
+            "whatever_pass",
+            verify_password=_always_true,
+            db=accounts.session,
+        )
+        assert result is None
+
+    def test_inactive_user_returns_none(self, accounts):
+        result = Auths.authenticate_user(
+            INACTIVE["email"],
+            "whatever_pass",
+            verify_password=_always_true,
+            db=accounts.session,
+        )
+        assert result is None
+
+    def test_hash_ok_but_wrong_raw_password_cannot_recover_dek(self, accounts):
+        result = Auths.authenticate_user(
+            ACTIVE["email"],
+            "not-the-real-password",
+            verify_password=_always_true,
+            db=accounts.session,
+        )
+        assert result is None


### PR DESCRIPTION
## Summary

親Issue #40 / 子Issue #45。`AuthsTable.authenticate_user`（`backend/open_webui/models/auths.py`）について、**ログイン時に保存済み `wrapped_dek` をパスワード由来のKEKで復号し、サインアップ時と同じ平文DEKを復元する**ことを検証する単体テストを追加する。

#43（作成時のDEK生成・保存）と対になる「復元側」のテスト。`authenticate_user` は2段で認証する：
1. `verify_password(auth.password)` … 保存済みハッシュとの照合（router層から渡されるコールバック）
2. `derive_kek(raw_password, kdf_salt)` → `unwrap_dek(wrapped_dek, kek)` … DEK復元

実際の鍵キャッシュ登録（`cache_dek`）は router 層の責務のため対象外。

## Changes

- `backend/open_webui/test/util/test_auths_login.py` を新規追加（7ケース）
  - **成功時**: 正しい資格情報で `UserWithDek` が返り、`user` が一致すること
  - **往復**: ログインで復元したDEKが、サインアップ時（`insert_new_auth`）のDEKと一致すること
  - **契約**: `verify_password` に保存済みハッシュ（`auth.password`）が渡されること
  - **失敗（ハッシュ不一致）**: `verify_password` が False → `None`
  - **失敗（未知メール）**: 存在しないメール → `None`
  - **失敗（無効ユーザー）**: `active=False` → `None`（暗号処理に到達せず弾かれる）
  - **失敗（誤生パスワード）**: ハッシュ照合を通っても、誤った生パスワードでは KEK が異なり `unwrap_dek` が `InvalidTag` → `None`
- 既存のモデル層テストに倣いインメモリSQLite（`Auth` / `User`）を使用
- Argon2id（2 GiB）は成功パスでのみ走るため、成功認証を module スコープのフィクスチャで1回だけ実行し再利用。無効ユーザーは暗号処理前に弾かれる前提なので、ダミー値の行を直接作成（導出コストなし）

## How to test

```
docker run --rm --entrypoint python `
  -e WEBUI_SECRET_KEY=test-secret-key -e ENABLE_DB_MIGRATIONS=false `
  -e "DATABASE_URL=sqlite:////tmp/owui-test.db" -e DATA_DIR=/tmp `
  -v "<repo>/backend:/app/backend" -w /app/backend `
  <python311-image> -m pytest open_webui/test/util/test_auths_login.py -v
```

- 7ケース全てpass（Python 3.11.14 / Linux、約6.8秒）

Closes #45
