### PR TITLE
test(auths): cover DEK re-wrapping at password change (#47)

### DIFF
--- a/backend/open_webui/test/util/test_auths_password_change.py
+++ b/backend/open_webui/test/util/test_auths_password_change.py
@@ -1,0 +1,166 @@
+from dataclasses import dataclass
+
+import pytest
+from cryptography.exceptions import InvalidTag
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker
+
+from open_webui.internal import db as internal_db
+from open_webui.internal.db import Base
+from open_webui.models.auths import Auth, Auths
+from open_webui.models.users import User
+from open_webui.utils.crypto_utils import derive_kek, unwrap_dek
+
+EMAIL = "alice@example.com"
+NAME = "Alice"
+OLD_RAW_PASSWORD = "alice-old-passphrase"
+OLD_HASH_PASSWORD = "hashed::alice-old"
+NEW_RAW_PASSWORD = "alice-new-passphrase"
+NEW_HASH_PASSWORD = "hashed::alice-new"
+
+
+def _raw_auth_row(session, user_id):
+    return session.execute(
+        text("SELECT kdf_salt, wrapped_dek, password FROM auth WHERE id = :id"),
+        {"id": user_id},
+    ).one()
+
+
+def _make_session():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine, tables=[User.__table__, Auth.__table__])
+    return engine, sessionmaker(bind=engine)()
+
+
+@dataclass
+class Changed:
+    session: object
+    user_id: str
+    result: bool
+    original_dek: bytes
+    original_salt: bytes
+    original_wrapped_dek: bytes
+    new_salt: bytes
+    new_wrapped_dek: bytes
+    new_password: str
+
+
+@pytest.fixture(scope="module")
+def changed() -> Changed:
+    mp = pytest.MonkeyPatch()
+    mp.setattr(internal_db, "DATABASE_ENABLE_SESSION_SHARING", True)
+    engine, session = _make_session()
+
+    created = Auths.insert_new_auth(
+        email=EMAIL,
+        hashed_password=OLD_HASH_PASSWORD,
+        name=NAME,
+        raw_password=OLD_RAW_PASSWORD,
+        role="user",
+        db=session,
+    )
+    user_id = created.user.id
+    original_salt, original_wrapped_dek, _ = _raw_auth_row(session, user_id)
+
+    result = Auths.update_user_password_by_id(
+        user_id,
+        NEW_HASH_PASSWORD,
+        NEW_RAW_PASSWORD,
+        OLD_RAW_PASSWORD,
+        db=session,
+    )
+
+    new_salt, new_wrapped_dek, new_password = _raw_auth_row(session, user_id)
+
+    yield Changed(
+        session=session,
+        user_id=user_id,
+        result=result,
+        original_dek=created.dek,
+        original_salt=original_salt,
+        original_wrapped_dek=original_wrapped_dek,
+        new_salt=new_salt,
+        new_wrapped_dek=new_wrapped_dek,
+        new_password=new_password,
+    )
+
+    session.close()
+    engine.dispose()
+    mp.undo()
+
+
+@dataclass
+class Rejected:
+    result: bool
+    before: tuple
+    after: tuple
+
+
+@pytest.fixture(scope="module")
+def rejected() -> Rejected:
+    mp = pytest.MonkeyPatch()
+    mp.setattr(internal_db, "DATABASE_ENABLE_SESSION_SHARING", True)
+    engine, session = _make_session()
+
+    created = Auths.insert_new_auth(
+        email=EMAIL,
+        hashed_password=OLD_HASH_PASSWORD,
+        name=NAME,
+        raw_password=OLD_RAW_PASSWORD,
+        role="user",
+        db=session,
+    )
+    user_id = created.user.id
+    before = _raw_auth_row(session, user_id)
+
+    result = Auths.update_user_password_by_id(
+        user_id,
+        NEW_HASH_PASSWORD,
+        NEW_RAW_PASSWORD,
+        "wrong-current-password",
+        db=session,
+    )
+
+    after = _raw_auth_row(session, user_id)
+
+    yield Rejected(result=result, before=before, after=after)
+
+    session.close()
+    engine.dispose()
+    mp.undo()
+
+
+class TestSuccessfulChange:
+    def test_returns_true(self, changed):
+        assert changed.result is True
+
+    def test_password_hash_updated(self, changed):
+        assert changed.new_password == NEW_HASH_PASSWORD
+
+    def test_wrapped_dek_is_rewrapped(self, changed):
+        assert changed.new_wrapped_dek != changed.original_wrapped_dek
+
+    def test_kdf_salt_is_reused(self, changed):
+        assert changed.new_salt == changed.original_salt
+
+    def test_dek_is_preserved_under_new_password(self, changed):
+        new_kek = derive_kek(NEW_RAW_PASSWORD, changed.new_salt)
+        assert unwrap_dek(changed.new_wrapped_dek, new_kek) == changed.original_dek
+
+
+class TestRejectedChange:
+    def test_wrong_current_password_returns_false(self, rejected):
+        assert rejected.result is False
+
+    def test_wrong_current_password_does_not_mutate(self, rejected):
+        assert rejected.after == rejected.before
+
+    def test_unknown_user_returns_false(self, changed):
+        result = Auths.update_user_password_by_id(
+            "no-such-user",
+            NEW_HASH_PASSWORD,
+            NEW_RAW_PASSWORD,
+            OLD_RAW_PASSWORD,
+            db=changed.session,
+        )
+        assert result is False


### PR DESCRIPTION
## Summary

親Issue #40 / 子Issue #47。`AuthsTable.update_user_password_by_id`（`backend/open_webui/models/auths.py`）について、**パスワード変更時にDEKを再ラップ（re-wrap）するだけで、DEK本体は不変＝既存データの再暗号化が不要**であることを検証する単体テストを追加する。

`update_user_password_by_id` の流れ：
1. 旧パスワード＋保存済みソルトで `current_kek` を導出し `wrapped_dek` をアンラップ → DEK取得
2. 新パスワード＋同じソルトで `new_kek` を導出し、同じDEKを再ラップ
3. `password`（ハッシュ）と `wrapped_dek` を更新

これにより、GB/TB級データの再暗号化なしにパスワード変更を実現する（計画書 3.3.3）。

### 実装の実態（テストで固定）
- **`kdf_salt` は流用**される（設計書は「新ソルト生成」だが、実装は同一ソルトを再利用）。テストは実装の実挙動を検証・明文化する。
- 現行パスワードが誤りの場合、`unwrap_dek` が `InvalidTag` → `except` で握り潰して `False`（DB無変更）。
- ユーザー不在 → `False`。

## Changes

- `backend/open_webui/test/util/test_auths_password_change.py` を新規追加（8ケース）
  - **TestSuccessfulChange**
    - 成功時に `True` を返すこと
    - `password` 列が新ハッシュに更新されること
    - `wrapped_dek` が再ラップされ変化すること
    - `kdf_salt` が据え置き（流用）であること
    - **新パスワード由来のKEKでアンラップすると、変更前と同じDEKが復元される**こと（DEK不変＝再暗号化不要）
  - **TestRejectedChange**
    - 誤った現行パスワード → `False`
    - 誤った現行パスワード → `wrapped_dek`/`password`/`kdf_salt` が無変更
    - 存在しないユーザー → `False`
- 既存のモデル層テストに倣いインメモリSQLite（`Auth` / `User`）を使用
- Argon2id（2 GiB）はパスワード変更ごとに2回（旧+新）走るため、成功変更と拒否変更を module スコープのフィクスチャで各1回だけ実行し再利用

## How to test

```
docker run --rm --entrypoint python `
  -e WEBUI_SECRET_KEY=test-secret-key -e ENABLE_DB_MIGRATIONS=false `
  -e "DATABASE_URL=sqlite:////tmp/owui-test.db" -e DATA_DIR=/tmp `
  -v "<repo>/backend:/app/backend" -w /app/backend `
  <python311-image> -m pytest open_webui/test/util/test_auths_password_change.py -v
```

- 8ケース全てpass（Python 3.11.14 / Linux、約9秒）

Closes #47
