### PR TITLE
test(crypto): cover per-user DEK isolation via ContextVars (#51)

### DIFF
--- a/backend/open_webui/test/util/test_crypto_context_isolation.py
+++ b/backend/open_webui/test/util/test_crypto_context_isolation.py
@@ -1,0 +1,101 @@
+import asyncio
+import time
+
+import pytest
+
+from open_webui.utils import crypto_context
+from open_webui.utils.crypto_context import (
+    cache_dek,
+    get_cached_dek,
+    get_current_user_id,
+    purge_expired_sessions,
+    remove_session,
+    require_cached_dek,
+    require_current_user_dek,
+    set_current_user_id,
+)
+from open_webui.crypto_exceptions import EncryptedDataAccessDeniedError
+from open_webui.utils.crypto_utils import generate_dek
+
+USER_A = "user-a"
+USER_B = "user-b"
+
+
+@pytest.fixture(autouse=True)
+def _isolate_cache():
+    crypto_context._dek_cache.clear()
+    set_current_user_id(None)
+    yield
+    set_current_user_id(None)
+    crypto_context._dek_cache.clear()
+
+
+@pytest.fixture
+def two_users():
+    dek_a = generate_dek()
+    dek_b = generate_dek()
+    cache_dek(USER_A, dek_a, jti="a-jti", expires_at=time.time() + 60)
+    cache_dek(USER_B, dek_b, jti="b-jti", expires_at=time.time() + 60)
+    return dek_a, dek_b
+
+
+class TestMultiUserCacheSeparation:
+    def test_each_user_gets_their_own_dek(self, two_users):
+        dek_a, dek_b = two_users
+        assert dek_a != dek_b
+        assert require_cached_dek(USER_A) == dek_a
+        assert require_cached_dek(USER_B) == dek_b
+
+    def test_removing_one_session_leaves_other_user_intact(self, two_users):
+        dek_a, dek_b = two_users
+        remove_session(USER_A, "a-jti")
+
+        assert get_cached_dek(USER_A) is None
+        assert require_cached_dek(USER_B) == dek_b
+
+    def test_expiring_one_user_leaves_other_user_intact(self):
+        dek_a = generate_dek()
+        dek_b = generate_dek()
+        cache_dek(USER_A, dek_a, jti="a-jti", expires_at=time.time() - 1)  # expired
+        cache_dek(USER_B, dek_b, jti="b-jti", expires_at=time.time() + 60)
+
+        purge_expired_sessions(time.time())
+
+        assert get_cached_dek(USER_A) is None
+        assert require_cached_dek(USER_B) == dek_b
+
+
+class TestCurrentUserDekSelection:
+    def test_context_selects_the_matching_users_dek(self, two_users):
+        dek_a, dek_b = two_users
+
+        set_current_user_id(USER_A)
+        assert get_current_user_id() == USER_A
+        assert require_current_user_dek(USER_A) == dek_a
+
+        set_current_user_id(USER_B)
+        assert require_current_user_dek(USER_B) == dek_b
+
+    def test_cross_user_denied_even_when_target_is_cached(self, two_users):
+        set_current_user_id(USER_A)
+        with pytest.raises(EncryptedDataAccessDeniedError):
+            require_current_user_dek(USER_B)
+
+
+class TestContextVarTaskIsolation:
+    def test_concurrent_asyncio_tasks_do_not_share_current_user(self):
+        results: dict[str, str] = {}
+
+        async def worker(user_id: str) -> None:
+            set_current_user_id(user_id)
+            await asyncio.sleep(0)
+            results[user_id] = get_current_user_id()
+
+        async def main() -> None:
+            await asyncio.gather(worker(USER_A), worker(USER_B))
+
+        asyncio.run(main())
+
+        assert results[USER_A] == USER_A
+        assert results[USER_B] == USER_B
+        assert get_current_user_id() is None


### PR DESCRIPTION
## Summary

親Issue #40 / 子Issue #51。`crypto_context.py`（ContextVar による「現在のユーザー」＋ユーザー別DEKメモリキャッシュ）について、**マルチユーザーでDEKが混線しないこと**と **ContextVar が並行タスク間で分離されること**を検証する単体テストを追加する。

既存 `test_crypto_context.py` は単一ユーザー経路をカバー済み。本PRは**ユーザー間分離**に絞って補完する。

## Changes

- `backend/open_webui/test/util/test_crypto_context_isolation.py` を新規追加（6ケース）
  - **TestMultiUserCacheSeparation**
    - 2ユーザー同時キャッシュ → それぞれ自分のDEKが返る（取り違えなし）
    - 片方のセッション削除（`remove_session`）が他ユーザーに影響しない
    - 片方の失効（`purge_expired_sessions`）が他ユーザーに影響しない
  - **TestCurrentUserDekSelection**
    - `require_current_user_dek` が ContextVar の現在ユーザーに応じて正しいDEKを選ぶ（A→B切替で返る鍵も切替）
    - **ターゲットのDEKがキャッシュ済みでも**、現在ユーザーと異なれば `EncryptedDataAccessDeniedError` で拒否（owner チェックが鍵返却より先＝キャッシュ存在による迂回がない）
  - **TestContextVarTaskIsolation**
    - 並行 asyncio タスク（`asyncio.gather` + `sleep(0)` で interleave）間で `current_user_id` が互いに漏れない。外側コンテキストもタスクの代入に影響されない
- DEK は乱数キー（Argon2idなし）のため高速

## How to test

本プロジェクトは Python 3.11+ 必須。Windows 開発機のローカル Python は 3.10 のため、3.11 環境（Docker / Ubuntu / CI）で実行する。

```
docker run --rm --entrypoint python `
  -e WEBUI_SECRET_KEY=test-secret-key -e ENABLE_DB_MIGRATIONS=false `
  -e "DATABASE_URL=sqlite:////tmp/owui-test.db" -e DATA_DIR=/tmp `
  -v "<repo>/backend:/app/backend" -w /app/backend `
  <python311-image> -m pytest open_webui/test/util/test_crypto_context_isolation.py -v
```

- 6ケース全てpass（Python 3.11.14 / Linux、約0.4秒）
- 干渉確認: `test_crypto_context.py` + `test_crypto_context_isolation.py` → 14 passed

Closes #51
