### PR TITLE
chore(dev): add secure-fork dev compose with containerized Ollama

### DIFF
--- a/docker-compose.secure-dev.yaml
+++ b/docker-compose.secure-dev.yaml
@@ -1,0 +1,55 @@
+services:
+  app:
+    build:
+      context: .
+    command:
+      - uvicorn
+      - open_webui.main:app
+      - --host=0.0.0.0
+      - --port=8080
+      - --reload
+      - --reload-dir=/app/backend/open_webui
+    working_dir: /app/backend
+    ports:
+      - "3001:8080"
+    environment:
+      WEBUI_SECRET_KEY: dev-secret-key
+      DATABASE_URL: postgresql://webui_user:changeme@db:5432/webui_db
+      OLLAMA_BASE_URL: http://ollama:11434
+    volumes:
+      - ./backend:/app/backend
+    cap_add:
+      - IPC_LOCK
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    depends_on:
+      ollama:
+        condition: service_healthy
+      db:
+        condition: service_started
+
+  db:
+    image: postgres:18-alpine
+    environment:
+      POSTGRES_USER: webui_user
+      POSTGRES_PASSWORD: changeme
+      POSTGRES_DB: webui_db
+    volumes:
+      - dev_db_data:/var/lib/postgresql/data
+
+  ollama:
+    image: ollama/ollama
+    volumes:
+      - ollama_data:/root/.ollama
+    healthcheck:
+      test: ["CMD", "ollama", "list"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
+
+volumes:
+  dev_db_data:
+  ollama_data:


### PR DESCRIPTION
## Summary

セキュア版フォークの**開発用 compose** を追加する。upstream の `docker-compose.yaml` とは別ファイル（`docker-compose.secure-dev.yaml`）にして、upstream 同期で衝突しないようにする。

狙い：**開発を Linux コンテナ内で完結**させ、本番(ai-server)同等の Postgres・コンテナ化 Ollama を同梱し、コードはバインドマウントでホットリロード。

## Changes

- `docker-compose.secure-dev.yaml` を新規追加：
  - **app**：ソースを `./backend` にバインドマウントし `uvicorn --reload` 起動。`cap_add: IPC_LOCK` ＋ `memlock -1` で **mlockall 成功**。ポートは **3001**（本番ミラーの ai-server :3000 と共存できるよう dev 側をずらす）
  - **db**：`postgres:18-alpine`（本番同等パリティ）
  - **ollama**：`ollama/ollama` をコンテナ化。`ollama_data` 永続ボリューム＋healthcheck（`ollama list`）
  - **依存関係**：app は `depends_on: ollama(condition: service_healthy)` / `db(service_started)` ＝ **Ollama が応答可能になってから app 起動**
  - 接続は **`OLLAMA_BASE_URL=http://ollama:11434`**（compose サービス名。`host.docker.internal` 依存を撤去）

## How to test

```bash
docker compose -f docker-compose.secure-dev.yaml up -d --build
# 依存順: db/ollama 起動 → ollama healthy → app 起動
docker compose -f docker-compose.secure-dev.yaml ps          # app/ollama healthy
docker exec <ollama container> ollama pull llama3            # 初回モデル取得
# ブラウザ http://localhost:3001 → モデル llama3 選択 → チャット
```

検証済み（Windows / Docker Desktop, CPU）：
- ビルド・起動成功、`mlockall ... memory locked successfully`
- 依存関係（ollama healthy 後に app 起動）を実機確認
- `llama3` 取得 → open-webui でモデル表示・**チャット応答**
- **モデル永続**：`down → up` で再DLなしに残存

GPU 連携は別途（CPU で動作）。本番(ai-server)への展開は zanaka/ai-server#3 Phase 2 で対応。

Related: zanaka/ai-server#1, zanaka/ai-server#3
