### PR TITLE
feat(crypto): アカウント作成時に RSA 鍵ペアを生成（秘密鍵は DEK 暗号）

### DIFF
--- a/backend/open_webui/migrations/versions/b2c3d4e5f6a7_add_user_keypair_to_auth.py
+++ b/backend/open_webui/migrations/versions/b2c3d4e5f6a7_add_user_keypair_to_auth.py
@@ -1,0 +1,27 @@
+"""Add per-user RSA keypair columns to auth table
+
+Revision ID: b2c3d4e5f6a7
+Revises: a1b2c3d4e5f6
+Create Date: 2026-06-19 00:00:00.000000
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "b2c3d4e5f6a7"
+down_revision = "a1b2c3d4e5f6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column("auth", sa.Column("public_key", sa.LargeBinary(), nullable=False))
+    op.add_column(
+        "auth", sa.Column("wrapped_private_key", sa.LargeBinary(), nullable=False)
+    )
+
+
+def downgrade():
+    op.drop_column("auth", "wrapped_private_key")
+    op.drop_column("auth", "public_key")

--- a/backend/open_webui/models/auths.py
+++ b/backend/open_webui/models/auths.py
@@ -11,6 +11,8 @@ from open_webui.utils.crypto_utils import (
     derive_kek,
     wrap_dek,
     unwrap_dek,
+    generate_rsa_keypair,
+    encrypt_value,
 )
 from dataclasses import dataclass, field
 
@@ -39,6 +41,8 @@ class Auth(Base):
     active = Column(Boolean)
     kdf_salt = Column(LargeBinary, nullable=False)
     wrapped_dek = Column(LargeBinary, nullable=False)
+    public_key = Column(LargeBinary, nullable=False)
+    wrapped_private_key = Column(LargeBinary, nullable=False)
 
 
 class AuthModel(BaseModel):
@@ -48,6 +52,8 @@ class AuthModel(BaseModel):
     active: bool = True
     kdf_salt: bytes
     wrapped_dek: bytes
+    public_key: bytes
+    wrapped_private_key: bytes
 
 
 ####################
@@ -120,6 +126,9 @@ class AuthsTable:
             kek = derive_kek(raw_password, kdf_salt)
             wrapped_dek = wrap_dek(dek, kek)
 
+            private_key_der, public_key_der = generate_rsa_keypair()
+            wrapped_private_key = encrypt_value(private_key_der, dek)
+
             auth = AuthModel(
                 id=id,
                 email=email,
@@ -127,6 +136,8 @@ class AuthsTable:
                 active=True,
                 kdf_salt=kdf_salt,
                 wrapped_dek=wrapped_dek,
+                public_key=public_key_der,
+                wrapped_private_key=wrapped_private_key,
             )
             result = Auth(**auth.model_dump())
             db.add(result)

--- a/backend/open_webui/test/util/test_auths_keypair.py
+++ b/backend/open_webui/test/util/test_auths_keypair.py
@@ -1,0 +1,142 @@
+import os
+from dataclasses import dataclass
+
+import pytest
+from cryptography.exceptions import InvalidTag
+from cryptography.hazmat.primitives import serialization
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker
+
+from open_webui.internal import db as internal_db
+from open_webui.internal.db import Base
+from open_webui.models.auths import Auth, Auths, UserWithDek
+from open_webui.models.users import User
+from open_webui.utils.crypto_utils import (
+    decrypt_value,
+    generate_rsa_keypair,
+    rsa_unwrap_key,
+    rsa_wrap_key,
+)
+
+USER_A = {
+    "email": "alice@example.com",
+    "name": "Alice",
+    "hashed_password": "hashed::alice",
+    "raw_password": "alice-correct-horse",
+}
+USER_B = {
+    "email": "bob@example.com",
+    "name": "Bob",
+    "hashed_password": "hashed::bob",
+    "raw_password": "bob-battery-staple",
+}
+
+
+@dataclass
+class Created:
+    session: object
+    a: UserWithDek
+    b: UserWithDek
+
+
+@pytest.fixture(scope="module")
+def created() -> Created:
+    mp = pytest.MonkeyPatch()
+    mp.setattr(internal_db, "DATABASE_ENABLE_SESSION_SHARING", True)
+
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine, tables=[User.__table__, Auth.__table__])
+    session = sessionmaker(bind=engine)()
+
+    a = Auths.insert_new_auth(
+        email=USER_A["email"],
+        hashed_password=USER_A["hashed_password"],
+        name=USER_A["name"],
+        raw_password=USER_A["raw_password"],
+        role="user",
+        db=session,
+    )
+    b = Auths.insert_new_auth(
+        email=USER_B["email"],
+        hashed_password=USER_B["hashed_password"],
+        name=USER_B["name"],
+        raw_password=USER_B["raw_password"],
+        role="user",
+        db=session,
+    )
+
+    yield Created(session=session, a=a, b=b)
+
+    session.close()
+    engine.dispose()
+    mp.undo()
+
+
+def _raw_keypair(session, user_id):
+    return session.execute(
+        text(
+            "SELECT public_key, wrapped_private_key FROM auth WHERE id = :id"
+        ),
+        {"id": user_id},
+    ).one()
+
+
+class TestPersistence:
+    def test_public_key_persisted_as_loadable_spki(self, created):
+        public_key, _ = _raw_keypair(created.session, created.a.user.id)
+        assert isinstance(public_key, bytes)
+        loaded = serialization.load_der_public_key(public_key)
+        assert loaded.key_size == 3072
+
+
+class TestPrivateKeyAtRest:
+    def test_private_key_is_not_stored_as_plaintext(self, created):
+        _, wrapped_private_key = _raw_keypair(created.session, created.a.user.id)
+        with pytest.raises(Exception):
+            serialization.load_der_private_key(wrapped_private_key, password=None)
+
+    def test_private_key_decrypts_with_owner_dek(self, created):
+        _, wrapped_private_key = _raw_keypair(created.session, created.a.user.id)
+        private_der = decrypt_value(wrapped_private_key, created.a.dek)
+        loaded = serialization.load_der_private_key(private_der, password=None)
+        assert loaded.key_size == 3072
+
+    def test_private_key_does_not_decrypt_with_other_users_dek(self, created):
+        _, wrapped_private_key = _raw_keypair(created.session, created.a.user.id)
+        with pytest.raises(InvalidTag):
+            decrypt_value(wrapped_private_key, created.b.dek)
+
+
+class TestStoredKeypairRoundtrip:
+    def test_stored_pub_and_decrypted_priv_form_a_working_pair(self, created):
+        public_key, wrapped_private_key = _raw_keypair(
+            created.session, created.a.user.id
+        )
+        private_der = decrypt_value(wrapped_private_key, created.a.dek)
+
+        material = os.urandom(32)
+        wrapped = rsa_wrap_key(material, public_key)
+        assert rsa_unwrap_key(wrapped, private_der) == material
+
+
+class TestKeySeparation:
+    def test_two_users_get_distinct_public_keys(self, created):
+        pub_a, _ = _raw_keypair(created.session, created.a.user.id)
+        pub_b, _ = _raw_keypair(created.session, created.b.user.id)
+        assert pub_a != pub_b
+
+
+class TestKeypairPrimitives:
+    def test_generate_keypair_roundtrip(self):
+        private_der, public_der = generate_rsa_keypair()
+        material = os.urandom(32)
+        wrapped = rsa_wrap_key(material, public_der)
+        assert wrapped != material
+        assert rsa_unwrap_key(wrapped, private_der) == material
+
+    def test_wrong_private_key_cannot_unwrap(self):
+        _, public_der = generate_rsa_keypair()
+        other_private_der, _ = generate_rsa_keypair()
+        wrapped = rsa_wrap_key(os.urandom(32), public_der)
+        with pytest.raises(ValueError):
+            rsa_unwrap_key(wrapped, other_private_der)

--- a/backend/open_webui/test/util/test_auths_login.py
+++ b/backend/open_webui/test/util/test_auths_login.py
@@ -78,6 +78,8 @@ def accounts() -> Accounts:
             active=False,
             kdf_salt=b"\x00" * 16,
             wrapped_dek=b"\x00" * 60,
+            public_key=b"\x00" * 32,
+            wrapped_private_key=b"\x00" * 32,
         )
     )
     session.commit()

--- a/backend/open_webui/utils/crypto_utils.py
+++ b/backend/open_webui/utils/crypto_utils.py
@@ -6,6 +6,8 @@ import struct
 from pathlib import Path
 from typing import Any, BinaryIO, Iterator, Optional
 
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import padding, rsa
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 from argon2.low_level import hash_secret_raw, Type
 
@@ -20,6 +22,15 @@ ARGON2_TIME_COST = 1
 ARGON2_MEMORY_COST = 2097152  # 2 GiB
 ARGON2_PARALLELISM = 4
 ARGON2_HASH_LEN = 32  # 256 bits
+
+# Per-user RSA keypair, used to wrap a 32-byte symmetric key (an AES-256 key)
+# for a recipient via RSA-OAEP-SHA256. 3072-bit gives 128-bit security.
+RSA_KEY_SIZE = 3072
+_RSA_OAEP_PADDING = padding.OAEP(
+    mgf=padding.MGF1(algorithm=hashes.SHA256()),
+    algorithm=hashes.SHA256(),
+    label=None,
+)
 
 # Chunked file encryption format
 FILE_MAGIC = b"OWUIFILEENC1\n"
@@ -73,6 +84,34 @@ def decrypt_value(encrypted_bytes: bytes, dek: bytes) -> bytes:
     ciphertext = encrypted_bytes[NONCE_SIZE:]
     aesgcm = AESGCM(dek)
     return aesgcm.decrypt(nonce, ciphertext, None)
+
+
+def generate_rsa_keypair() -> tuple[bytes, bytes]:
+    private_key = rsa.generate_private_key(
+        public_exponent=65537, key_size=RSA_KEY_SIZE
+    )
+    private_der = private_key.private_bytes(
+        encoding=serialization.Encoding.DER,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    public_der = private_key.public_key().public_bytes(
+        encoding=serialization.Encoding.DER,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    return private_der, public_der
+
+
+def rsa_wrap_key(key_material: bytes, public_key_spki_der: bytes) -> bytes:
+    public_key = serialization.load_der_public_key(public_key_spki_der)
+    return public_key.encrypt(key_material, _RSA_OAEP_PADDING)
+
+
+def rsa_unwrap_key(wrapped_key: bytes, private_key_pkcs8_der: bytes) -> bytes:
+    private_key = serialization.load_der_private_key(
+        private_key_pkcs8_der, password=None
+    )
+    return private_key.decrypt(wrapped_key, _RSA_OAEP_PADDING)
 
 
 def encrypt_text(value: Optional[str], dek: bytes) -> Optional[str]:


### PR DESCRIPTION
Closes #55 (親: #54)

## Summary

暗号化ナレッジ共有（#54）の土台として、**アカウント作成時に per-user の RSA 鍵ペア**を生成する。秘密鍵は所有者の DEK で暗号化（wrap）して保存し、公開鍵は平文で保存する。後続フェーズで、この公開鍵を使ってナレッジ別 KDEK をユーザーごとにラップする。

統合点は `insert_new_auth`。`kdf_salt` / `wrapped_dek` を作るのと同じ場所で、生成直後の DEK を使って秘密鍵を wrap する。

## Changes

- **`crypto_utils.py`**: RSA ユーティリティを追加
  - `generate_rsa_keypair()` → `(private_pkcs8_der, public_spki_der)`（RSA-3072）
  - `rsa_wrap_key()` / `rsa_unwrap_key()`（RSA-OAEP-SHA256。KDEK ラップ用、本PRではラウンドトリップ検証に使用）
  - 秘密鍵の at-rest 暗号化は既存 `encrypt_value` / `decrypt_value`（DEK, AES-GCM）を再利用
- **`models/auths.py`**: `auth` テーブルに `public_key` / `wrapped_private_key`（ともに NOT NULL）を追加。`insert_new_auth` で鍵ペアを生成し、秘密鍵を DEK で wrap して保存
- **migration `b2c3d4e5f6a7`**: 上記2カラムを追加（`a1b2c3d4e5f6` の後続）。すべてのアカウント作成は `insert_new_auth` を通り常に値が入るため NOT NULL
- **tests**: `test_auths_keypair.py` を追加（8 ケース）。`test_auths_login.py` は手動構築の inactive `Auth` 行に新カラムを補完

## How to test

Docker（Python 3.11）でユニットテスト：

```sh
docker exec -w /app/backend <app-container> \
  python -m pytest open_webui/test/util/test_auths_keypair.py -v
```

確認内容：
- サインアップで鍵ペアが生成・永続化される（公開鍵は平文 SPKI、秘密鍵は暗号文）
- 秘密鍵は所有者 DEK で復号でき、他ユーザーの DEK では `InvalidTag`
- 保存された公開鍵と復号した秘密鍵が対として機能（wrap→unwrap ラウンドトリップ）
- 2ユーザーは異なる公開鍵を持つ

回帰：`test_auths_user_creation.py` / `test_auths_login.py` / `test_auths_password_change.py` も通過（計33）。

